### PR TITLE
Revert "Update journey conditionally on day change"

### DIFF
--- a/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
@@ -53,41 +53,11 @@ class JourneyRepository @Inject constructor(
         try {
             val isDayChanged = isDayChanged(extractedLocation, lastKnownJourney)
 
-            if (isDayChanged && extractedLocation != null) {
-                val geometricMedian = locationCache.getLastFiveLocations(userId)?.let {
-                    geometricMedian(it)
-                } ?: extractedLocation
-
-                val lastKnownLocation = if (lastKnownJourney.isSteadyLocation()) {
-                    lastKnownJourney.toLocationFromSteadyJourney()
-                } else {
-                    lastKnownJourney.toLocationFromMovingJourney()
-                }
-
-                val distance = distanceBetween(geometricMedian, lastKnownLocation)
-
-                if (distance < MIN_DISTANCE && distance > 0) {
-                    // Here, means user is at same location on day changed
-                    // Save last known journey with updated day
-                    saveJourneyOnDayChanged(userId, lastKnownJourney)
-                } else {
-                    // Here means, user has moved to new location on day changed
-                    // Save new location journey with steady state
-                    var newJourneyId = ""
-                    journeyService.saveCurrentJourney(
-                        userId = userId,
-                        fromLatitude = extractedLocation.latitude,
-                        fromLongitude = extractedLocation.longitude,
-                        createdAt = extractedLocation.time
-                    ) {
-                        newJourneyId = it
-                    }
-                    val locationJourney =
-                        extractedLocation.toLocationJourney(userId, newJourneyId)
-                    locationCache.putLastJourney(locationJourney, userId)
-                }
-            } else if (isDayChanged) {
+            if (isDayChanged) {
+                // Day is changed between last known journey and current location
+                // Just save again the last known journey in remote database with updated day i.e., current time
                 saveJourneyOnDayChanged(userId, lastKnownJourney)
+                return
             }
         } catch (e: Exception) {
             Timber.e(e, "Error while saving location journey on day changed")
@@ -169,8 +139,7 @@ class JourneyRepository @Inject constructor(
                 ) {
                     newJourneyId = it
                 }
-                val locationJourney = extractedLocation?.toLocationJourney(userid, newJourneyId)
-                    ?: return LocationJourney()
+                val locationJourney = extractedLocation?.toLocationJourney(userid, newJourneyId) ?: return LocationJourney()
                 locationCache.putLastJourney(locationJourney, userid)
                 locationManager.updateRequestBasedOnState(isMoving = false)
                 return locationJourney


### PR DESCRIPTION
Reverts canopas/group-track-android#111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of location journeys, simplifying the process for saving and updating journeys based on day changes.
	- Enhanced clarity in the logic for determining when to create new location journeys.

- **Bug Fixes**
	- Streamlined the flow for retrieving last known locations, reducing complexity and potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->