### PR TITLE
Modify on-day changed logic and timeline screen api call

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="AndroidLintUnsafeImplicitIntentLaunch" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,6 +105,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+        isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
         jvmTarget = "1.8"
@@ -204,6 +205,9 @@ dependencies {
 
     // Splash screen
     implementation("androidx.core:core-splashscreen:1.0.1")
+
+    // Desugaring
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.3")
 
     implementation(project(":data"))
 }

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
@@ -177,7 +177,11 @@ fun SteadyLocationItem(
 
         // Determine the end time for duration calculation
         val endTime = when {
-            nextJourney != null -> nextJourney.created_at!!
+            nextJourney != null -> if (isFirstItem) {
+                minOf(System.currentTimeMillis(), endOfSteadyDay)
+            } else {
+                nextJourney.created_at!!
+            }
             else -> minOf(System.currentTimeMillis(), endOfSteadyDay)
         }
 

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
@@ -177,7 +177,7 @@ fun SteadyLocationItem(
 
         // Determine the end time for duration calculation
         val endTime = when {
-            nextJourney != null -> minOf(nextJourney.created_at!!, endOfSteadyDay)
+            nextJourney != null -> nextJourney.created_at!!
             else -> minOf(System.currentTimeMillis(), endOfSteadyDay)
         }
 

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineViewModel.kt
@@ -53,19 +53,9 @@ class JourneyTimelineViewModel @Inject constructor(
     }
 
     private fun setSelectedTimeRange() {
-        val calendar = Calendar.getInstance()
-        calendar.timeInMillis = System.currentTimeMillis()
-        calendar.set(Calendar.HOUR_OF_DAY, 0)
-        calendar.set(Calendar.MINUTE, 0)
-        val timestampFrom = calendar.timeInMillis
-
-        calendar.set(Calendar.HOUR_OF_DAY, 23)
-        calendar.set(Calendar.MINUTE, 59)
-        val timestampTo = calendar.timeInMillis
-
         _state.value = _state.value.copy(
-            selectedTimeFrom = timestampFrom,
-            selectedTimeTo = timestampTo
+            selectedTimeFrom = getTodayStartTimestamp(),
+            selectedTimeTo = getTodayEndTimestamp()
         )
     }
 

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineViewModel.kt
@@ -48,7 +48,25 @@ class JourneyTimelineViewModel @Inject constructor(
 
     init {
         fetchUser()
+        setSelectedTimeRange()
         loadLocations()
+    }
+
+    private fun setSelectedTimeRange() {
+        val calendar = Calendar.getInstance()
+        calendar.timeInMillis = System.currentTimeMillis()
+        calendar.set(Calendar.HOUR_OF_DAY, 0)
+        calendar.set(Calendar.MINUTE, 0)
+        val timestampFrom = calendar.timeInMillis
+
+        calendar.set(Calendar.HOUR_OF_DAY, 23)
+        calendar.set(Calendar.MINUTE, 59)
+        val timestampTo = calendar.timeInMillis
+
+        _state.value = _state.value.copy(
+            selectedTimeFrom = timestampFrom,
+            selectedTimeTo = timestampTo
+        )
     }
 
     private fun fetchUser() = viewModelScope.launch(appDispatcher.IO) {
@@ -89,7 +107,7 @@ class JourneyTimelineViewModel @Inject constructor(
             }
 
             val filteredLocations = locations.filter {
-                it.created_at!! in from!!..to!!
+                it.created_at!! in from..to || it.update_at!! in from..to
             }
 
             val locationJourneys = (allJourneys + filteredLocations).groupByDate()
@@ -238,8 +256,8 @@ class JourneyTimelineViewModel @Inject constructor(
 data class JourneyTimelineState(
     val isCurrentUserTimeline: Boolean = false,
     val selectedUser: ApiUser? = null,
-    val selectedTimeFrom: Long? = null,
-    val selectedTimeTo: Long? = null,
+    val selectedTimeFrom: Long = System.currentTimeMillis(),
+    val selectedTimeTo: Long = System.currentTimeMillis(),
     val isLoading: Boolean = false,
     val appending: Boolean = false,
     val groupedLocation: Map<Long, List<LocationJourney>> = emptyMap(),

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineViewModel.kt
@@ -98,7 +98,7 @@ class JourneyTimelineViewModel @Inject constructor(
         try {
             val from = _state.value.selectedTimeFrom
             val to = _state.value.selectedTimeTo
-            val lastJourneyTime = allJourneys.minOfOrNull { it.created_at!! }
+            val lastJourneyTime = allJourneys.minOfOrNull { it.update_at!! }
 
             val locations = if (loadMore) {
                 journeyService.getMoreJourneyHistory(userId, lastJourneyTime)
@@ -107,7 +107,8 @@ class JourneyTimelineViewModel @Inject constructor(
             }
 
             val filteredLocations = locations.filter {
-                it.created_at!! in from..to || it.update_at!! in from..to
+                (it.created_at?.let { created -> created in from..to } ?: false) ||
+                    (it.update_at?.let { updated -> updated in from..to } ?: false)
             }
 
             val locationJourneys = (allJourneys + filteredLocations).groupByDate()

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -29,6 +29,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+        isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
         jvmTarget = "1.8"
@@ -76,6 +77,9 @@ dependencies {
     implementation("androidx.room:room-runtime:2.6.1")
     ksp("androidx.room:room-compiler:2.6.1")
     implementation("androidx.room:room-ktx:2.6.1")
+
+    // Desugaring
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.3")
 
     // Place
     implementation("com.google.android.libraries.places:places:4.0.0")

--- a/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
@@ -11,6 +11,9 @@ import com.canopas.yourspace.data.service.location.ApiJourneyService
 import com.canopas.yourspace.data.service.location.LocationManager
 import com.canopas.yourspace.data.storage.LocationCache
 import timber.log.Timber
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import java.util.Calendar
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -90,13 +93,15 @@ class JourneyRepository @Inject constructor(
         extractedLocation: Location? = null,
         lastKnownJourney: LocationJourney
     ): Boolean {
-        val calendar = Calendar.getInstance()
-        calendar.timeInMillis = lastKnownJourney.update_at!!
-        val lastKnownDay = calendar.get(Calendar.DAY_OF_MONTH)
-        calendar.timeInMillis = extractedLocation?.time ?: System.currentTimeMillis()
-        val currentDay = calendar.get(Calendar.DAY_OF_MONTH)
-        val daysPassed = currentDay - lastKnownDay
-        return daysPassed == 1
+        val lastKnownDate = Instant.ofEpochMilli(lastKnownJourney.update_at!!)
+            .atZone(ZoneId.systemDefault())
+            .toLocalDate()
+        val currentDate =
+            Instant.ofEpochMilli(extractedLocation?.time ?: System.currentTimeMillis())
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate()
+        val daysPassed = ChronoUnit.DAYS.between(lastKnownDate, currentDate)
+        return daysPassed == 1L
     }
 
     /**

--- a/data/src/main/java/com/canopas/yourspace/data/service/location/ApiJourneyService.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/location/ApiJourneyService.kt
@@ -1,5 +1,6 @@
 package com.canopas.yourspace.data.service.location
 
+import android.util.Log
 import com.canopas.yourspace.data.models.location.JourneyRoute
 import com.canopas.yourspace.data.models.location.LocationJourney
 import com.canopas.yourspace.data.utils.Config
@@ -95,28 +96,24 @@ class ApiJourneyService @Inject constructor(
 
     suspend fun getJourneyHistory(
         userId: String,
-        from: Long? = null,
-        to: Long? = null
+        from: Long,
+        to: Long
     ): List<LocationJourney> {
-        if (from == null) {
-            return journeyRef(userId).whereEqualTo("user_id", userId)
-                .orderBy("created_at", Query.Direction.DESCENDING)
-                .limit(20)
-                .get().await().documents.mapNotNull { it.toObject<LocationJourney>() }
-        } else if (to == null) {
-            return journeyRef(userId).whereEqualTo("user_id", userId)
-                .whereGreaterThanOrEqualTo("created_at", from)
-                .orderBy("created_at", Query.Direction.DESCENDING)
-                .limit(20)
-                .get().await().documents.mapNotNull { it.toObject<LocationJourney>() }
-        } else {
-            return journeyRef(userId).whereEqualTo("user_id", userId)
-                .whereGreaterThanOrEqualTo("created_at", from)
-                .whereLessThanOrEqualTo("created_at", to)
-                .orderBy("created_at", Query.Direction.DESCENDING)
-                .limit(20)
-                .get().await().documents.mapNotNull { it.toObject<LocationJourney>() }
-        }
+        val previousDayJourney = journeyRef(userId).whereEqualTo("user_id", userId)
+            .whereLessThan("created_at", from)
+            .whereGreaterThanOrEqualTo("update_at", from)
+            .limit(1)
+            .get().await().documents.mapNotNull { it.toObject<LocationJourney>() }
+
+        val currentDayJourney = journeyRef(userId).whereEqualTo("user_id", userId)
+            .whereGreaterThanOrEqualTo("created_at", from)
+            .whereLessThanOrEqualTo("created_at", to)
+            .orderBy("created_at", Query.Direction.DESCENDING)
+            .limit(20)
+            .get().await().documents.mapNotNull { it.toObject<LocationJourney>() }
+
+        Log.e("XXXXXX", "Previous Day Journey: $previousDayJourney")
+        return previousDayJourney + currentDayJourney
     }
 
     suspend fun getLocationJourneyFromId(userId: String, journeyId: String): LocationJourney? {

--- a/data/src/main/java/com/canopas/yourspace/data/service/location/ApiJourneyService.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/location/ApiJourneyService.kt
@@ -1,6 +1,5 @@
 package com.canopas.yourspace.data.service.location
 
-import android.util.Log
 import com.canopas.yourspace.data.models.location.JourneyRoute
 import com.canopas.yourspace.data.models.location.LocationJourney
 import com.canopas.yourspace.data.utils.Config
@@ -112,7 +111,6 @@ class ApiJourneyService @Inject constructor(
             .limit(20)
             .get().await().documents.mapNotNull { it.toObject<LocationJourney>() }
 
-        Log.e("XXXXXX", "Previous Day Journey: $previousDayJourney")
         return previousDayJourney + currentDayJourney
     }
 


### PR DESCRIPTION
# Changelog

- We now show previous day's journey on current/selected day with relevant time calculation

https://github.com/user-attachments/assets/9e9ac953-6c09-4d4f-bbba-9dd83b1c624c





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new inspection tool for Android Lint to enhance code quality checks.
  - Updated location history display to include the duration of steady locations.

- **Improvements**
  - Enhanced journey filtering logic to include journeys based on both creation and update timestamps.
  - Streamlined the logic for saving and updating journeys based on day changes, improving user experience.
  - Improved parameter validation in the journey history retrieval process, ensuring more reliable data fetching.
  - Enabled core library desugaring for better compatibility with newer Java features on older Android versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->