### PR TITLE
Refactor steadyTime Logic and Simplify updateJourneyOnDayChange

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
@@ -177,10 +177,10 @@ fun SteadyLocationItem(
 
         // Determine the end time for duration calculation
         val endTime = when {
-            nextJourney != null -> if (isFirstItem) {
+            nextJourney != null -> if (nextJourney.created_at!! > endOfSteadyDay) {
                 minOf(System.currentTimeMillis(), endOfSteadyDay)
             } else {
-                nextJourney.created_at!!
+                location.update_at!!
             }
             else -> minOf(System.currentTimeMillis(), endOfSteadyDay)
         }

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
@@ -177,12 +177,14 @@ fun SteadyLocationItem(
 
         // Determine the end time for duration calculation
         val endTime = when {
-            nextJourney != null -> if (nextJourney.created_at!! > endOfSteadyDay) {
+            nextJourney != null -> if (isFirstItem) {
                 minOf(System.currentTimeMillis(), endOfSteadyDay)
             } else {
                 location.update_at!!
             }
-            else -> minOf(System.currentTimeMillis(), endOfSteadyDay)
+            else -> {
+                minOf(System.currentTimeMillis(), location.update_at!!)
+            }
         }
 
         val durationMillis = endTime - createdAt

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
@@ -172,18 +172,16 @@ fun SteadyLocationItem(
 
         val createdAt = location.created_at ?: System.currentTimeMillis()
 
-        // Calculate the end of the day timestamp for this steady location
-        val endOfSteadyDay = getEndOfDayTimestamp(createdAt)
-
-        // Determine the end time for duration calculation
         val endTime = when {
-            nextJourney != null -> if (isFirstItem) {
-                minOf(System.currentTimeMillis(), endOfSteadyDay)
-            } else {
+            nextJourney != null -> {
                 location.update_at!!
             }
             else -> {
-                minOf(System.currentTimeMillis(), location.update_at!!)
+                if (isSameDay(location.created_at!!, location.update_at!!)) {
+                    System.currentTimeMillis()
+                } else {
+                    minOf(System.currentTimeMillis(), location.update_at!!)
+                }
             }
         }
 
@@ -245,13 +243,11 @@ fun SteadyLocationItem(
     }
 }
 
-fun getEndOfDayTimestamp(startAt: Long): Long {
-    val cal = Calendar.getInstance().apply {
-        timeInMillis = startAt
-        set(Calendar.HOUR_OF_DAY, 23)
-        set(Calendar.MINUTE, 59)
-    }
-    return cal.timeInMillis
+fun isSameDay(timestamp1: Long, timestamp2: Long): Boolean {
+    val cal1 = Calendar.getInstance().apply { timeInMillis = timestamp1 }
+    val cal2 = Calendar.getInstance().apply { timeInMillis = timestamp2 }
+    return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) &&
+            cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR)
 }
 
 fun formatSteadyDuration(durationMillis: Long): String {

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
@@ -176,6 +176,7 @@ fun SteadyLocationItem(
             nextJourney != null -> {
                 location.update_at!!
             }
+
             else -> {
                 if (isSameDay(location.created_at!!, location.update_at!!)) {
                     System.currentTimeMillis()
@@ -246,8 +247,9 @@ fun SteadyLocationItem(
 fun isSameDay(timestamp1: Long, timestamp2: Long): Boolean {
     val cal1 = Calendar.getInstance().apply { timeInMillis = timestamp1 }
     val cal2 = Calendar.getInstance().apply { timeInMillis = timestamp2 }
-    return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) &&
-            cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR)
+    return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) && cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(
+        Calendar.DAY_OF_YEAR
+    )
 }
 
 fun formatSteadyDuration(durationMillis: Long): String {

--- a/data/src/main/java/com/canopas/yourspace/data/models/location/LocationJourney.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/models/location/LocationJourney.kt
@@ -19,7 +19,7 @@ data class LocationJourney(
     val route_duration: Long? = null,
     val routes: List<JourneyRoute> = emptyList(),
     val created_at: Long? = System.currentTimeMillis(),
-    val update_at: Long? = System.currentTimeMillis()
+    var update_at: Long? = System.currentTimeMillis()
 )
 
 @Keep

--- a/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
@@ -135,17 +135,14 @@ class JourneyRepository @Inject constructor(
         userId: String,
         lastKnownJourney: LocationJourney
     ) {
-        journeyService.updateLastLocationJourney(
-            userId = userId,
-            journey = lastKnownJourney.copy(
-                update_at = System.currentTimeMillis()
-            )
-        )
-        val newJourney = lastKnownJourney.copy(
-            created_at = System.currentTimeMillis(),
+        val updatedJourney = lastKnownJourney.copy(
             update_at = System.currentTimeMillis()
         )
-        locationCache.putLastJourney(newJourney, userId)
+        journeyService.updateLastLocationJourney(
+            userId = userId,
+            journey = updatedJourney
+        )
+        locationCache.putLastJourney(updatedJourney, userId)
     }
 
     /**
@@ -267,6 +264,15 @@ class JourneyRepository @Inject constructor(
         distance: Float,
         duration: Long = 0
     ) {
+        //Update the last steady journey's `updated_at` with this new moving journey's `created_at`
+        val updatedSteadyJourney = lastKnownJourney.copy(
+            update_at = System.currentTimeMillis()
+        )
+        journeyService.updateLastLocationJourney(
+            userId = userId,
+            journey = updatedSteadyJourney
+        )
+
         val lastFiveLocations = locationCache.getLastFiveLocations(userId) ?: emptyList()
         var newJourneyId = ""
         val journey = LocationJourney(

--- a/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
@@ -177,7 +177,8 @@ class JourneyRepository @Inject constructor(
                 ) {
                     newJourneyId = it
                 }
-                val locationJourney = extractedLocation?.toLocationJourney(userid, newJourneyId) ?: return LocationJourney()
+                val locationJourney = extractedLocation?.toLocationJourney(userid, newJourneyId)
+                    ?: return LocationJourney()
                 locationCache.putLastJourney(locationJourney, userid)
                 locationManager.updateRequestBasedOnState(isMoving = false)
                 return locationJourney
@@ -264,7 +265,7 @@ class JourneyRepository @Inject constructor(
         distance: Float,
         duration: Long = 0
     ) {
-        //Update the last steady journey's `updated_at` with this new moving journey's `created_at`
+        // Update the last steady journey's `updated_at` with this new moving journey's `created_at`
         val updatedSteadyJourney = lastKnownJourney.copy(
             update_at = System.currentTimeMillis()
         )


### PR DESCRIPTION

# Changelog

- Refactor code for calculating the time for steadyLocation
- Remove createdAt from updateJourneyOnDayChanged

## Breaking Changes

- Previous it was calculating the steady time from next journey's createdAt.
- It was updating the createdAt time for steady Location when the day was changing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced accuracy in calculating the duration of steady locations.
	- Improved display of steady duration in the user interface.

- **Bug Fixes**
	- Streamlined handling of location journeys, ensuring correct updates and state transitions.

- **Refactor**
	- Improved code clarity and efficiency in journey management logic, including updates to journey timestamps.

- **Chores**
	- Minor adjustments to code formatting and structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->