### PR TITLE
Update loading state management when loading more journeys.

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineViewModel.kt
@@ -158,7 +158,8 @@ class JourneyTimelineViewModel @Inject constructor(
 
     fun loadMoreLocations() {
         state.value.let {
-            if (it.hasMoreLocations && !it.appending) {
+            if (it.hasMoreLocations && !it.appending && it.isLoadingMore) {
+                _state.value = _state.value.copy(isLoadingMore = false)
                 loadLocations(true)
             }
         }
@@ -254,5 +255,6 @@ data class JourneyTimelineState(
     val groupedLocation: Map<Long, List<LocationJourney>> = emptyMap(),
     val hasMoreLocations: Boolean = true,
     val showDatePicker: Boolean = false,
-    val error: String? = null
+    val error: String? = null,
+    val isLoadingMore: Boolean = false
 )


### PR DESCRIPTION
# Changelog

[Added loading state for "Load More" functionality in Journey Timeline]

## New Features

- Added `isLoadingMore` state to the `JourneyTimelineState` to manage the loading state for "LoadMore" functionality in the journey timeline.

## Bug Fixes

- Fixed issue where "Load More" would trigger multiple loading requests simultaneously, improving the user experience by ensuring only one load operation occurs at a time.


https://github.com/user-attachments/assets/c16c8004-518d-43d7-89a3-56c71f63a481


https://github.com/user-attachments/assets/5e09e31e-9cd5-494a-8f0c-79668cb7889c







