### PR TITLE
Revert "Update moving journey at an interval of 1 minute"

### DIFF
--- a/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
@@ -21,6 +21,7 @@ import kotlin.math.sqrt
 
 const val MIN_DISTANCE = 150.0 // 150 meters
 const val MIN_TIME_DIFFERENCE = 5 * 60 * 1000 // 5 minutes
+const val MIN_DISTANCE_FOR_MOVING = 10.0 // 10 meters
 
 @Singleton
 class JourneyRepository @Inject constructor(
@@ -231,17 +232,7 @@ class JourneyRepository @Inject constructor(
             }
         } else {
             // Handle moving user
-            if (distance > MIN_DISTANCE) {
-                // Here, means last known journey is moving and user is still moving
-                // Save journey for moving user and update last known journey.
-                // Note: Need to use lastKnownJourney.id as journey id because we are updating the journey
-                updateJourneyForContinuedMovingUser(
-                    userId,
-                    extractedLocation,
-                    lastKnownJourney,
-                    distance
-                )
-            } else if (distance < MIN_DISTANCE && timeDifference > MIN_TIME_DIFFERENCE) {
+            if (distance < MIN_DISTANCE && timeDifference > MIN_TIME_DIFFERENCE) {
                 // Here, means last known journey is moving and user has stopped moving
                 // Save journey for steady user and update last known journey:
                 saveJourneyOnJourneyStopped(
@@ -251,6 +242,16 @@ class JourneyRepository @Inject constructor(
                     distance
                 )
                 locationManager.updateRequestBasedOnState(isMoving = false)
+            } else if (distance > MIN_DISTANCE_FOR_MOVING) {
+                // Here, means last known journey is moving and user is still moving
+                // Save journey for moving user and update last known journey.
+                // Note: Need to use lastKnownJourney.id as journey id because we are updating the journey
+                updateJourneyForContinuedMovingUser(
+                    userId,
+                    extractedLocation,
+                    lastKnownJourney,
+                    distance
+                )
             }
         }
     }

--- a/data/src/main/java/com/canopas/yourspace/data/service/location/LocationManager.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/location/LocationManager.kt
@@ -22,7 +22,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val LOCATION_UPDATE_INTERVAL = 10000L // 10 seconds
-private const val STEADY_UPDATE_INTERVAL = 60000L // 1 minute
+private const val STEADY_UPDATE_INTERVAL = 30000L // 30 seconds
 
 @SuppressLint("MissingPermission")
 @Singleton

--- a/data/src/main/java/com/canopas/yourspace/data/storage/LocationCache.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/storage/LocationCache.kt
@@ -10,6 +10,7 @@ import javax.inject.Singleton
 class LocationCache @Inject constructor() {
     private val lastJourneyCache = LruCache<String, LocationJourney>(25)
     private val lastFiveLocationsCache = LruCache<String, List<Location>>(25)
+    private val lastJourneyUpdatedTime = LruCache<String, Long>(25)
 
     fun putLastJourney(journey: LocationJourney, userId: String) {
         lastJourneyCache.put(userId, journey)
@@ -25,6 +26,14 @@ class LocationCache @Inject constructor() {
 
     fun getLastFiveLocations(userId: String): List<Location>? {
         return lastFiveLocationsCache.get(userId) ?: null
+    }
+
+    fun putLastJourneyUpdatedTime(time: Long, userId: String) {
+        lastJourneyUpdatedTime.put(userId, time)
+    }
+
+    fun getLastJourneyUpdatedTime(userId: String): Long {
+        return lastJourneyUpdatedTime.get(userId) ?: System.currentTimeMillis()
     }
 
     fun clear() {

--- a/data/src/main/java/com/canopas/yourspace/data/storage/LocationCache.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/storage/LocationCache.kt
@@ -10,7 +10,6 @@ import javax.inject.Singleton
 class LocationCache @Inject constructor() {
     private val lastJourneyCache = LruCache<String, LocationJourney>(25)
     private val lastFiveLocationsCache = LruCache<String, List<Location>>(25)
-    private val lastJourneyUpdatedTime = LruCache<String, Long>(1)
 
     fun putLastJourney(journey: LocationJourney, userId: String) {
         lastJourneyCache.put(userId, journey)
@@ -26,14 +25,6 @@ class LocationCache @Inject constructor() {
 
     fun getLastFiveLocations(userId: String): List<Location>? {
         return lastFiveLocationsCache.get(userId) ?: null
-    }
-
-    fun putLastJourneyUpdatedTime(time: Long, userId: String) {
-        lastJourneyUpdatedTime.put(userId, time)
-    }
-
-    fun getLastJourneyUpdatedTime(userId: String): Long {
-        return lastJourneyUpdatedTime.get(userId) ?: System.currentTimeMillis()
     }
 
     fun clear() {


### PR DESCRIPTION
Reverts canopas/group-track-android#117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for saving and updating location journeys based on user movement, simplifying conditions for journey updates.
	- Increased the frequency of location updates for steady users from 1 minute to 30 seconds.
	- Expanded the capacity of the journey update time cache from 1 to 25 entries.

- **Bug Fixes**
	- Removed unnecessary distance checks for journey updates, ensuring more accurate journey saving when users stop or continue moving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->