### PR TITLE
Fix extractLocationName issue for moving journey.

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
@@ -182,6 +182,7 @@ fun SteadyLocationItem(
             } else {
                 nextJourney.created_at!!
             }
+
             else -> minOf(System.currentTimeMillis(), endOfSteadyDay)
         }
 
@@ -462,7 +463,7 @@ internal fun getFormattedLocationTimeForFirstItem(createdAt: Long): String {
 
 fun Address.formattedTitle(toAddress: Address?): String {
     val fromName = extractLocationName(this)
-    val toName = toAddress?.let { extractLocationName(it) } ?: "Unknown"
+    val toName = toAddress?.let { extractLocationName(it) } ?: "Unknown Road"
 
     return if (toAddress == null) {
         fromName
@@ -474,18 +475,21 @@ fun Address.formattedTitle(toAddress: Address?): String {
 private fun extractLocationName(address: Address): String {
     val featureName = address.featureName?.trim()
     val thoroughfare = address.thoroughfare?.trim()
-    val locality = address.locality?.trim()
-    val subThoroughfare = address.subThoroughfare?.trim()
 
     val potentialNames = listOf(
         featureName,
-        thoroughfare,
-        locality,
-        subThoroughfare
+        thoroughfare
     ).filterNot { it.isNullOrEmpty() }
 
-    val name = potentialNames.firstOrNull { it?.matches(Regex("[^0-9]+")) == true }
-        ?: potentialNames.firstOrNull() ?: "Unknown"
+    val cleanedNames = potentialNames.map { it?.replace(Regex("^[A-Za-z0-9]+\\+.*"), "")?.trim() }
+    val name = cleanedNames.firstOrNull { it?.isNotEmpty() == true } ?: "Unknown Road"
 
-    return name.replace(Regex("^[0-9]+\\s*"), "").trim().ifEmpty { "Unknown" }
+    val resultName = if (name.matches(Regex("^[0-9].*"))) {
+        val streetName = cleanedNames.getOrNull(1) ?: ""
+        "$name $streetName".trim()
+    } else {
+        name
+    }
+
+    return resultName
 }


### PR DESCRIPTION
# Changelog

Fix Address Extraction Logic to Properly Handle Numbers and Null Components

## Bug Fixes

- Fixed issue where the street number was ignored in the address extraction process, ensuring that "123 Main St" and "456 Other St" are now properly combined into "123 Main St ➝ 456 Other St".

![Screenshot_20241128_135138](https://github.com/user-attachments/assets/eb116880-719c-41fc-ba23-b0ad4e231f90)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved location name clarity by refining the logic for displaying addresses, ensuring more descriptive results.
	- Defaulted to "Unknown Road" for unspecified addresses, enhancing user understanding of location data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->