### PR TITLE
Fix the internet error for SpaceInviteCodeScreen.

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/space/create/SpaceInviteCodeScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/space/create/SpaceInviteCodeScreen.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.canopas.yourspace.R
+import com.canopas.yourspace.domain.utils.ConnectivityObserver
+import com.canopas.yourspace.ui.component.AppBanner
 import com.canopas.yourspace.ui.component.PrimaryButton
 import com.canopas.yourspace.ui.theme.AppTheme
 
@@ -44,6 +46,12 @@ import com.canopas.yourspace.ui.theme.AppTheme
 fun SpaceInvite() {
     val viewModel = hiltViewModel<SpaceInviteCodeViewModel>()
     val state by viewModel.state.collectAsState()
+
+    if (state.error != null) {
+        AppBanner(msg = state.error!!) {
+            viewModel.resetErrorState()
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.onStart()
@@ -68,7 +76,15 @@ fun SpaceInvite() {
             },
             actions = {
                 if (state.isUserAdmin) {
-                    IconButton(onClick = { viewModel.regenerateInviteCode() }) {
+                    IconButton(
+                        onClick = {
+                            if (state.connectivityStatus == ConnectivityObserver.Status.Available) {
+                                viewModel.regenerateInviteCode()
+                            } else {
+                                viewModel.setErrorState(Exception())
+                            }
+                        }
+                    ) {
                         Icon(
                             imageVector = Icons.Default.Refresh,
                             contentDescription = ""

--- a/app/src/test/java/com/canopas/yourspace/ui/flow/home/space/create/SpaceInviteCodeViewModelTest.kt
+++ b/app/src/test/java/com/canopas/yourspace/ui/flow/home/space/create/SpaceInviteCodeViewModelTest.kt
@@ -6,10 +6,12 @@ import com.canopas.yourspace.data.repository.SpaceRepository
 import com.canopas.yourspace.data.service.auth.AuthService
 import com.canopas.yourspace.data.service.space.SpaceInvitationService
 import com.canopas.yourspace.data.utils.AppDispatcher
+import com.canopas.yourspace.domain.utils.ConnectivityObserver
 import com.canopas.yourspace.ui.navigation.AppDestinations.SpaceInvitation.KEY_INVITE_CODE
 import com.canopas.yourspace.ui.navigation.AppDestinations.SpaceInvitation.KEY_SPACE_NAME
 import com.canopas.yourspace.ui.navigation.AppNavigator
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Before
 import org.junit.Rule
@@ -30,18 +32,22 @@ class SpaceInviteCodeViewModelTest {
     private val spaceRepository = mock<SpaceRepository>()
     private val spaceInvitationService = mock<SpaceInvitationService>()
     private val authService = mock<AuthService>()
+    private val connectivityObserver = mock<ConnectivityObserver>()
 
     private lateinit var viewModel: SpaceInviteCodeViewModel
 
     @Before
     fun setViewModel() {
+        whenever(connectivityObserver.observe()).thenReturn(flowOf(ConnectivityObserver.Status.Available))
+
         viewModel = SpaceInviteCodeViewModel(
             appNavigator = appNavigator,
             savedStateHandle = savedStateHandle,
             appDispatcher = testDispatcher,
             spaceRepository = spaceRepository,
             spaceInvitationService = spaceInvitationService,
-            authService = authService
+            authService = authService,
+            connectivityObserver = connectivityObserver
         )
     }
 


### PR DESCRIPTION
# Changelog

Added internet error for spaceInviteCodeScreen.

## New Features

- Added a functionality to check the internet connection 

## Bug Fixes

- At the spaceInviteCodeScreen if admin lost internet connection then still admin can change the code.

![Screenshot_20241129_181821_GroupTrack](https://github.com/user-attachments/assets/597d63df-7f04-40af-b978-820f022256ea)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and connectivity checks in the Space Invite feature.
	- Users will receive notifications via an AppBanner for any errors encountered.
	- Invite code regeneration is now contingent on the user's internet connectivity status.

- **Bug Fixes**
	- Improved robustness in managing connectivity issues related to invite code functionality.

- **Tests**
	- Updated tests to include connectivity observer, ensuring accurate response to connectivity changes during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->