### PR TITLE
Fix direct navigation to home screen when no space is available after signin.

### DIFF
--- a/data/src/main/java/com/canopas/yourspace/data/repository/SpaceRepository.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/SpaceRepository.kt
@@ -197,9 +197,14 @@ class SpaceRepository @Inject constructor(
         invitationService.deleteInvitations(spaceId)
         spaceService.deleteSpace(spaceId)
         val userId = authService.currentUser?.id ?: ""
-        currentSpaceId =
-            getUserSpaces(userId).firstOrNull()?.sortedBy { it.created_at }?.firstOrNull()?.id
-                ?: ""
+        val user = userService.getUser(userId)
+        val updatedSpaceIds = user?.space_ids?.toMutableList()?.apply {
+            remove(spaceId)
+        } ?: return
+
+        user.copy(space_ids = updatedSpaceIds).let {
+            userService.updateUser(it)
+        }
     }
 
     suspend fun leaveSpace(spaceId: String) {


### PR DESCRIPTION
# Changelog

Fixed issue where users with no available space were still navigated to the Home Screen.

## Bug Fixes

- Fixed navigation issue where users with no available space were incorrectly redirected to the Home Screen instead of the Space Info Onboarding Screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved management of user space IDs during space deletion and user removal processes.
	- Enhanced logic for updating the current space ID after leaving or deleting a space.

- **Bug Fixes**
	- Resolved issues related to incorrect space ID management when users leave or are removed from spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->