### PR TITLE
Fix the location journey update on multiple day change.

### DIFF
--- a/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/JourneyRepository.kt
@@ -192,6 +192,8 @@ class JourneyRepository @Inject constructor(
         extractedLocation: Location,
         lastKnownJourney: LocationJourney
     ) {
+        if (isDayChanged(extractedLocation, lastKnownJourney)) return
+
         val geometricMedian = locationCache.getLastFiveLocations(userId)?.let {
             geometricMedian(it)
         }


### PR DESCRIPTION
# Changelog
-Addressed the issue where a moving journey was created between the last location and the current location when the user reinstalled the app after a few days.

## Breaking Changes
- Previously, reinstalling the app after several days caused the creation of an invalid moving journey between the last known location and the current location.

## New Features
- Introduced a condition to check whether the last journey's timestamp is more than 1 day ago, preventing incorrect journey updates.

## Bug Fixes
- Fixed the issue where outdated journeys were incorrectly updated or re-created upon app reinstallation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of location journeys by adding a condition to prevent processing when the day changes, enhancing accuracy in tracking user movement.
  
- **Refactor**
	- Updated the logic in the location journey management to include an early return condition, streamlining processing based on temporal context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->