### PR TITLE
Implement map style preference on JourneyTimelineScreen and DetailScreen.

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/JourneyMap.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/JourneyMap.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import com.canopas.yourspace.R
 import com.canopas.yourspace.data.models.location.LocationJourney
 import com.canopas.yourspace.data.models.location.toRoute
@@ -26,6 +27,7 @@ import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.MapStyleOptions
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MapType
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.MarkerComposable
 import com.google.maps.android.compose.Polyline
@@ -42,7 +44,8 @@ fun JourneyMap(
     polyLineWidth: Float = 5f,
     anchor: Offset = Offset(0.5f, 1.0f),
     shouldAnimate: Boolean = false,
-    onMapTap: (() -> Unit) = { }
+    onMapTap: () -> Unit = { },
+    selectedMapStyle: String
 ) {
     val fromLatLang = LatLng(location?.from_latitude ?: 0.0, location?.from_longitude ?: 0.0)
     val toLatLang = LatLng(location?.to_latitude ?: 0.0, location?.to_longitude ?: 0.0)
@@ -51,17 +54,26 @@ fun JourneyMap(
     }
     val animatedProgress = remember { Animatable(0f) }
 
+    val terrainStyle = stringResource(R.string.map_style_terrain)
+    val satelliteStyle = stringResource(R.string.map_style_satellite)
+
+    val mapStyleOptions = remember(selectedMapStyle) {
+        when (selectedMapStyle) {
+            terrainStyle -> MapType.TERRAIN
+            satelliteStyle -> MapType.SATELLITE
+            else -> MapType.NORMAL
+        }
+    }
     val isDarkMode = isSystemInDarkTheme()
     val context = LocalContext.current
-    val mapProperties = remember(isDarkMode) {
-        MapProperties(
-            mapStyleOptions = if (isDarkMode) {
-                MapStyleOptions.loadRawResourceStyle(context, R.raw.map_theme_night)
-            } else {
-                null
-            }
-        )
-    }
+    val mapProperties = MapProperties(
+        mapStyleOptions = if (isDarkMode) {
+            MapStyleOptions.loadRawResourceStyle(context, R.raw.map_theme_night)
+        } else {
+            null
+        },
+        mapType = mapStyleOptions
+    )
 
     // Calculate the route points
     val routePoints = location?.toRoute() ?: listOf()

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/components/LocationHistory.kt
@@ -68,19 +68,25 @@ fun LocationHistoryItem(
     isLastItem: Boolean,
     journeyList: List<LocationJourney>,
     addPlaceTap: (latitude: Double, longitude: Double) -> Unit,
-    showJourneyDetails: () -> Unit
+    showJourneyDetails: () -> Unit,
+    selectedMapStyle: String
 ) {
     if (location.isSteadyLocation()) {
         SteadyLocationItem(location, isFirstItem, isLastItem, journeyList) {
             addPlaceTap(location.from_latitude, location.from_longitude)
         }
     } else {
-        JourneyLocationItem(location, isLastItem, showJourneyDetails)
+        JourneyLocationItem(location, isLastItem, showJourneyDetails, selectedMapStyle)
     }
 }
 
 @Composable
-fun JourneyLocationItem(location: LocationJourney, lastItem: Boolean, onTap: () -> Unit) {
+fun JourneyLocationItem(
+    location: LocationJourney,
+    lastItem: Boolean,
+    onTap: () -> Unit,
+    selectedMapStyle: String
+) {
     val context = LocalContext.current
     var fromAddress by remember { mutableStateOf<Address?>(null) }
     var toAddress by remember { mutableStateOf<Address?>(null) }
@@ -136,7 +142,8 @@ fun JourneyLocationItem(location: LocationJourney, lastItem: Boolean, onTap: () 
                         modifier = Modifier.size(28.dp)
                     )
                 },
-                onMapTap = onTap
+                onMapTap = onTap,
+                selectedMapStyle = selectedMapStyle
             )
         }
     }

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/detail/UserJourneyDetailScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/detail/UserJourneyDetailScreen.kt
@@ -83,7 +83,7 @@ fun UserJourneyDetailScreen() {
                     .padding(it)
                     .fillMaxSize()
             ) {
-                MapView(state.journey)
+                MapView(state.journey, state.selectedMapStyle)
                 FooterContent(state.isLoading, state.journey)
             }
         } else {
@@ -220,7 +220,7 @@ private fun JourneyTopBar(journey: LocationJourney?, navigateBack: () -> Unit) {
 }
 
 @Composable
-private fun ColumnScope.MapView(journey: LocationJourney?) {
+private fun ColumnScope.MapView(journey: LocationJourney?, selectedMapStyle: String) {
     JourneyMap(
         modifier = Modifier
             .fillMaxWidth()
@@ -251,7 +251,8 @@ private fun ColumnScope.MapView(journey: LocationJourney?) {
         },
         shouldAnimate = true,
         polyLineWidth = 8f,
-        anchor = Offset(0.5f, 0.5f)
+        anchor = Offset(0.5f, 0.5f),
+        selectedMapStyle = selectedMapStyle
     )
 }
 

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/detail/UserJourneyDetailViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/detail/UserJourneyDetailViewModel.kt
@@ -9,6 +9,7 @@ import com.canopas.yourspace.data.models.user.ApiUser
 import com.canopas.yourspace.data.service.location.ApiJourneyService
 import com.canopas.yourspace.data.service.location.LocationManager
 import com.canopas.yourspace.data.service.user.ApiUserService
+import com.canopas.yourspace.data.storage.UserPreferences
 import com.canopas.yourspace.data.utils.AppDispatcher
 import com.canopas.yourspace.domain.utils.ConnectivityObserver
 import com.canopas.yourspace.ui.navigation.AppDestinations.UserJourneyDetails.KEY_JOURNEY_ID
@@ -30,7 +31,8 @@ class UserJourneyDetailViewModel @Inject constructor(
     private val locationManager: LocationManager,
     private val apiUserService: ApiUserService,
     private val navigator: AppNavigator,
-    private val connectivityObserver: ConnectivityObserver
+    private val connectivityObserver: ConnectivityObserver,
+    private val userPreferences: UserPreferences
 ) : ViewModel() {
 
     private var journeyId: String = savedStateHandle.get<String>(KEY_JOURNEY_ID)
@@ -49,7 +51,8 @@ class UserJourneyDetailViewModel @Inject constructor(
             _state.value = _state.value.copy(
                 journeyId = journeyId,
                 user = user,
-                currentLocation = currentLocation
+                currentLocation = currentLocation,
+                selectedMapStyle = userPreferences.currentMapStyle ?: ""
             )
         }
         fetchJourney()
@@ -118,5 +121,6 @@ data class UserJourneyDetailState(
     val journeyId: String? = null,
     val journey: LocationJourney? = null,
     val connectivityStatus: ConnectivityObserver.Status = ConnectivityObserver.Status.Available,
-    val error: String? = null
+    val error: String? = null,
+    var selectedMapStyle: String = ""
 )

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/detail/UserJourneyDetailViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/detail/UserJourneyDetailViewModel.kt
@@ -122,5 +122,5 @@ data class UserJourneyDetailState(
     val journey: LocationJourney? = null,
     val connectivityStatus: ConnectivityObserver.Status = ConnectivityObserver.Status.Available,
     val error: String? = null,
-    var selectedMapStyle: String = ""
+    val selectedMapStyle: String = ""
 )

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineScreen.kt
@@ -139,7 +139,8 @@ private fun TimelineContent(modifier: Modifier) {
                     journeys = state.groupedLocation,
                     onScrollToBottom = viewModel::loadMoreLocations,
                     onAddPlaceClicked = viewModel::addPlace,
-                    showJourneyDetails = viewModel::showJourneyDetails
+                    showJourneyDetails = viewModel::showJourneyDetails,
+                    selectedMapStyle = state.selectedMapStyle
                 )
             }
         }
@@ -154,7 +155,8 @@ private fun JourneyList(
     journeys: Map<Long, List<LocationJourney>>,
     onScrollToBottom: () -> Unit,
     onAddPlaceClicked: (Double, Double) -> Unit,
-    showJourneyDetails: (String) -> Unit
+    showJourneyDetails: (String) -> Unit,
+    selectedMapStyle: String
 ) {
     val lazyState = rememberLazyListState()
     val reachedBottom by remember {
@@ -186,7 +188,8 @@ private fun JourneyList(
                 journeyList = allJourney,
                 showJourneyDetails = {
                     showJourneyDetails(journey.id)
-                }
+                },
+                selectedMapStyle = selectedMapStyle
             )
         }
 

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/journey/timeline/JourneyTimelineViewModel.kt
@@ -9,6 +9,7 @@ import com.canopas.yourspace.data.repository.JourneyRepository
 import com.canopas.yourspace.data.service.auth.AuthService
 import com.canopas.yourspace.data.service.location.ApiJourneyService
 import com.canopas.yourspace.data.service.user.ApiUserService
+import com.canopas.yourspace.data.storage.UserPreferences
 import com.canopas.yourspace.data.utils.AppDispatcher
 import com.canopas.yourspace.domain.utils.ConnectivityObserver
 import com.canopas.yourspace.ui.navigation.AppDestinations
@@ -31,7 +32,8 @@ class JourneyTimelineViewModel @Inject constructor(
     private val authService: AuthService,
     private val journeyRepository: JourneyRepository,
     private val appDispatcher: AppDispatcher,
-    private val connectivityObserver: ConnectivityObserver
+    private val connectivityObserver: ConnectivityObserver,
+    private val userPreferences: UserPreferences
 ) : ViewModel() {
 
     private var userId: String =
@@ -54,6 +56,9 @@ class JourneyTimelineViewModel @Inject constructor(
         fetchUser()
         setSelectedTimeRange()
         loadLocations()
+        _state.value = state.value.copy(
+            selectedMapStyle = userPreferences.currentMapStyle ?: ""
+        )
     }
 
     private fun setSelectedTimeRange() {
@@ -274,5 +279,6 @@ data class JourneyTimelineState(
     val showDatePicker: Boolean = false,
     val connectivityStatus: ConnectivityObserver.Status = ConnectivityObserver.Status.Available,
     val error: String? = null,
-    val isLoadingMore: Boolean = true
+    val isLoadingMore: Boolean = true,
+    val selectedMapStyle: String = ""
 )


### PR DESCRIPTION
# Changelog

Implemented functionality to apply saved map style on JourneyTimelineScreen and JourneyDetailScreen.

## New Features

- Added the functionality to persist and apply the user's selected map style across JourneyTimelineScreen and JourneyDetailScreen.
- Integrated map style preference handling based on the user’s selection on the Home Screen.

## Enhancements

- Improved consistency by ensuring the selected map style is applied across multiple screens.




https://github.com/user-attachments/assets/74ac4665-91ab-4041-a38c-04763d4f6a99



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced customizable map styles in the Journey Map, allowing users to select between different visual representations, including terrain and satellite views.
  - Enhanced location history components to support the selected map style, improving the visual experience of journey locations.
  
- **Improvements**
  - Integrated user preferences for map styles in the journey detail and timeline screens, personalizing the user experience based on individual settings.

These updates aim to provide users with more control over how they view their journeys, enhancing overall usability and visual appeal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->