### PR TITLE
Add a validation for delete account.

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/settings/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/settings/profile/EditProfileScreen.kt
@@ -199,7 +199,11 @@ private fun EditProfileScreenContent(modifier: Modifier) {
                 label = stringResource(id = R.string.settings_btn_delete_account),
                 onClick = {
                     if (state.connectivityStatus == ConnectivityObserver.Status.Available) {
-                        viewModel.showDeleteAccountConfirmation(true)
+                        if (state.adminGroupList.isNotEmpty()) {
+                            viewModel.showAdminChangeDialog(true)
+                        } else {
+                            viewModel.showDeleteAccountConfirmation(true)
+                        }
                     } else {
                         Toast.makeText(
                             context,
@@ -224,6 +228,10 @@ private fun EditProfileScreenContent(modifier: Modifier) {
 
         if (state.showDeleteAccountConfirmation) {
             ShowDeleteAccountDialog(viewModel)
+        }
+
+        if (state.showAdminChangeDialog) {
+            ShowAdminChangeDialog(viewModel)
         }
     }
 }
@@ -294,4 +302,25 @@ fun UserTextField(
             color = outlineColor
         )
     }
+}
+
+@Composable
+fun ShowAdminChangeDialog(viewModel: EditProfileViewModel) {
+    val state by viewModel.state.collectAsState()
+
+    AppAlertDialog(
+        title = stringResource(R.string.account_deletion_change_admin_dialog_title),
+        subTitle = stringResource(
+            R.string.account_deletion_change_admin_dialog_subtitle,
+            state.adminGroupList.joinToString(separator = "\n") { "\u2022 ${it.name}" }
+        ),
+        confirmBtnText = stringResource(R.string.common_btn_ok),
+        dismissBtnText = stringResource(R.string.common_btn_cancel),
+        onConfirmClick = {
+            viewModel.showAdminChangeDialog(false)
+            viewModel.popBackStack()
+        },
+        onDismissClick = { viewModel.showAdminChangeDialog(false) },
+        isConfirmDestructive = false
+    )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -304,4 +304,7 @@
 
     <string name="place_list_screen_no_members_title">Add members to add places</string>
     <string name="place_list_screen_no_members_subtitle">At least one member needs to join your group to be able to add places.</string>
+
+    <string name="account_deletion_change_admin_dialog_title">Reassign Admin Before Deletion</string>
+    <string name="account_deletion_change_admin_dialog_subtitle">Please assign a new admin before proceeding with the account deletion to avoid data loss. \nYou are an admin of the following groups :\n%1$s</string>
 </resources>

--- a/data/src/main/java/com/canopas/yourspace/data/repository/SpaceRepository.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/SpaceRepository.kt
@@ -227,6 +227,14 @@ class SpaceRepository @Inject constructor(
         spaceService.updateSpace(newSpace)
     }
 
+    suspend fun isUserAdminOfAnySpace(userId: String): Boolean {
+        val spaces = getUserSpaces(userId).firstOrNull() ?: return false
+        return spaces.any { space ->
+            space.admin_id == userId &&
+                (spaceService.getMemberBySpaceId(space.id).firstOrNull()?.size ?: 1) > 1
+        }
+    }
+
     suspend fun removeUserFromSpace(spaceId: String, userId: String) {
         spaceService.removeUserFromSpace(spaceId, userId)
         val user = userService.getUser(userId)


### PR DESCRIPTION
# Changelog

Added validation to prevent accidental deletion of groups and their data when a user with admin roles tries to delete their account.

## New Features

- Added validation to check if the user has the admin role in any group before allowing account deletion.
- Introduced a dialog prompt to notify users with admin roles in groups to assign new admins before account deletion.

## Bug Fixes

- Fixed an issue where deleting the user's account would unintentionally remove all spaces and data across all groups the user was a part of.

## Enhancements

- Enhanced account deletion flow to include a check for admin roles in any groups.
- Display a list of groups where the user is an admin, allowing them to reassign admin roles before proceeding with account deletion.


https://github.com/user-attachments/assets/f0ce8ee1-d5aa-445a-890d-bc5166596c06



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced account deletion process with a confirmation dialog for users in admin groups.
  - Added functionality to display admin group information before account deletion.

- **Bug Fixes**
  - Improved error handling during account deletion and admin space fetching.

- **Documentation**
  - New string resources added for dialog titles and messages related to account deletion.

- **Chores**
  - Updated ViewModel and repository methods to support new admin checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->