### PR TITLE
Update UI for SpaceInviteCode regeneration.

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/space/create/SpaceInviteCodeScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/space/create/SpaceInviteCodeScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -36,7 +34,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.canopas.yourspace.R
-import com.canopas.yourspace.domain.utils.ConnectivityObserver
 import com.canopas.yourspace.ui.component.AppBanner
 import com.canopas.yourspace.ui.component.PrimaryButton
 import com.canopas.yourspace.ui.theme.AppTheme
@@ -62,7 +59,7 @@ fun SpaceInvite() {
             colors = TopAppBarDefaults.topAppBarColors(containerColor = AppTheme.colorScheme.surface),
             title = {
                 Text(
-                    text = stringResource(id = R.string.space_inviate_code_title),
+                    text = stringResource(id = R.string.space_invite_code_title),
                     style = AppTheme.appTypography.subTitle1
                 )
             },
@@ -72,24 +69,6 @@ fun SpaceInvite() {
                         painter = painterResource(id = R.drawable.ic_nav_back_arrow_icon),
                         contentDescription = ""
                     )
-                }
-            },
-            actions = {
-                if (state.isUserAdmin) {
-                    IconButton(
-                        onClick = {
-                            if (state.connectivityStatus == ConnectivityObserver.Status.Available) {
-                                viewModel.regenerateInviteCode()
-                            } else {
-                                viewModel.setErrorState(Exception())
-                            }
-                        }
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Refresh,
-                            contentDescription = ""
-                        )
-                    }
                 }
             }
         )

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/space/create/SpaceInviteCodeViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/space/create/SpaceInviteCodeViewModel.kt
@@ -83,13 +83,6 @@ class SpaceInviteCodeViewModel @Inject constructor(
         }
     }
 
-    fun regenerateInviteCode() = viewModelScope.launch(appDispatcher.IO) {
-        if (state.value.isUserAdmin) {
-            spaceRepository.regenerateInviteCode(spaceRepository.currentSpaceId)
-        }
-        fetchInviteCode()
-    }
-
     fun checkInternetConnection() {
         viewModelScope.launch(appDispatcher.IO) {
             connectivityObserver.observe().collectLatest { status ->
@@ -104,14 +97,6 @@ class SpaceInviteCodeViewModel @Inject constructor(
 
     fun resetErrorState() {
         _state.value = _state.value.copy(error = null)
-    }
-
-    fun setErrorState(exception: Exception) {
-        viewModelScope.launch {
-            _state.emit(
-                _state.value.copy(error = exception)
-            )
-        }
     }
 }
 

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/settings/space/SpaceProfileScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/settings/space/SpaceProfileScreen.kt
@@ -1,5 +1,7 @@
 package com.canopas.yourspace.ui.flow.settings.space
 
+import android.content.Context
+import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -21,6 +23,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -44,6 +48,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -236,6 +241,7 @@ private fun SpaceProfileContent() {
     val viewModel = hiltViewModel<SpaceProfileViewModel>()
     val state by viewModel.state.collectAsState()
     val scrollState = rememberScrollState()
+    val context = LocalContext.current
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -251,6 +257,42 @@ private fun SpaceProfileContent() {
                 onValueChange = {
                     viewModel.onNameChanged(it.trimStart())
                 }
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = stringResource(R.string.space_invite_code_title),
+                style = AppTheme.appTypography.body2,
+                color = AppTheme.colorScheme.textDisabled,
+                modifier = Modifier.padding(start = 8.dp)
+            )
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(horizontal = 8.dp)
+            ) {
+                Text(
+                    text = state.inviteCode,
+                    modifier = Modifier.weight(1f),
+                    style = AppTheme.appTypography.header4
+                )
+                IconButton(
+                    onClick = { shareInvitationCode(context = context, code = state.inviteCode) }
+                ) {
+                    Icon(Icons.Default.Share, contentDescription = "")
+                }
+                if (state.isAdmin) {
+                    IconButton(onClick = { viewModel.regenerateInviteCode() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "")
+                    }
+                }
+            }
+            Text(
+                text = stringResource(R.string.code_expire_text, state.codeExpireTime),
+                style = AppTheme.appTypography.body2,
+                color = AppTheme.colorScheme.textDisabled,
+                modifier = Modifier.padding(start = 8.dp)
             )
 
             HorizontalDivider(
@@ -351,6 +393,20 @@ private fun SpaceProfileContent() {
             )
         }
     }
+}
+
+private fun shareInvitationCode(context: Context, code: String) {
+    val sendIntent: Intent = Intent().apply {
+        action = Intent.ACTION_SEND
+        putExtra(
+            Intent.EXTRA_TEXT,
+            context.getString(R.string.common_share_invite_code_message, code)
+        )
+        type = "text/plain"
+    }
+
+    val shareIntent = Intent.createChooser(sendIntent, null)
+    context.startActivity(shareIntent)
 }
 
 @Composable

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/settings/space/SpaceProfileScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/settings/space/SpaceProfileScreen.kt
@@ -289,7 +289,7 @@ private fun SpaceProfileContent() {
                 }
             }
             Text(
-                text = stringResource(R.string.code_expire_text, state.codeExpireTime),
+                text = stringResource(R.string.space_invite_code_expire_text, state.codeExpireTime),
                 style = AppTheme.appTypography.body2,
                 color = AppTheme.colorScheme.textDisabled,
                 modifier = Modifier.padding(start = 8.dp)

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/settings/space/edit/ChangeAdminScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/settings/space/edit/ChangeAdminScreen.kt
@@ -1,5 +1,9 @@
 package com.canopas.yourspace.ui.flow.settings.space.edit
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -18,12 +23,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -33,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -133,16 +138,26 @@ private fun UserItem(
             modifier = Modifier.weight(1f)
         )
 
-        RadioButton(
-            selected = isSelected,
-            onClick = { onUserSelect(userInfo.user.id) },
-            enabled = true,
-            colors = RadioButtonDefaults.colors(
-                selectedColor = AppTheme.colorScheme.primary,
-                unselectedColor = AppTheme.colorScheme.textDisabled
-            ),
-            modifier = Modifier.padding(end = 4.dp)
-        )
+        Box(
+            modifier = Modifier
+                .clip(CircleShape)
+                .size(24.dp)
+                .background(if (isSelected) AppTheme.colorScheme.primary else AppTheme.colorScheme.surface)
+                .border(1.dp, AppTheme.colorScheme.primary, CircleShape)
+                .clickable(enabled = !isSelected) {
+                    onUserSelect(userInfo.user.id)
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            if (isSelected) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = "",
+                    tint = AppTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        }
     }
 }
 
@@ -174,14 +189,18 @@ fun ChangeAdminAppBar(selectedUserId: String?) {
             }
         },
         actions = {
-            IconButton(
-                onClick = { selectedUserId?.let { viewModel.changeAdmin(it) } }
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Check,
-                    contentDescription = ""
-                )
-            }
+            Text(
+                text = stringResource(id = R.string.edit_profile_toolbar_save_text),
+                color = AppTheme.colorScheme.primary,
+                style = AppTheme.appTypography.button,
+                modifier = Modifier
+                    .padding(end = 8.dp)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = ripple(bounded = false),
+                        onClick = { selectedUserId?.let { viewModel.changeAdmin(it) } }
+                    )
+            )
         }
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,9 +134,10 @@
         <item>Blood Bond</item>
     </string-array>
 
-    <string name="space_inviate_code_title">Invite Code</string>
+    <string name="space_invite_code_title">Invite Code</string>
     <string name="space_invite_title">Invite members to the %s</string>
     <string name="space_invite_subtitle">Share this invite code with your trusted ones in your own style. Connecting is as flexible as you are.</string>
+    <string name="space_invite_code_expire_text">Code will expire in %1$s</string>
 
     <string name="join_space_title_enter_code">Enter the invite code</string>
     <string name="join_space_title">Join Group</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,7 +134,7 @@
         <item>Blood Bond</item>
     </string-array>
 
-    <string name="space_inviate_code_title">Invite Code</string>
+    <string name="space_invite_code_title">Invite Code</string>
     <string name="space_invite_title">Invite members to the %s</string>
     <string name="space_invite_subtitle">Share this invite code with your trusted ones in your own style. Connecting is as flexible as you are.</string>
 
@@ -304,4 +304,5 @@
 
     <string name="place_list_screen_no_members_title">Add members to add places</string>
     <string name="place_list_screen_no_members_subtitle">At least one member needs to join your group to be able to add places.</string>
+    <string name="code_expire_text">Code will expire in %1$s</string>
 </resources>

--- a/data/src/main/java/com/canopas/yourspace/data/repository/SpaceRepository.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/SpaceRepository.kt
@@ -175,6 +175,11 @@ class SpaceRepository @Inject constructor(
         return code?.code
     }
 
+    suspend fun getCurrentSpaceInviteCodeExpireTime(spaceId: String): Long? {
+        val code = invitationService.getSpaceInviteCode(spaceId)
+        return code?.created_at
+    }
+
     suspend fun enableLocation(spaceId: String, userId: String, locationEnabled: Boolean) {
         spaceService.enableLocation(spaceId, userId, locationEnabled)
     }


### PR DESCRIPTION
# Changelog
- Change the functinaity for regenrating the spaceInviteCode

## New Features

- Show groupInviteCode at the spaceSettingsScreen with the functionality of regenrating the spaceCode & Share Code.
- Add text for showing the expire time for current spaceInviteCode.


https://github.com/user-attachments/assets/699bfb0b-9e6b-42f1-82c7-e8afa7b58fb2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Users can now share invitation codes directly from the Space Profile screen.
	- A new method for regenerating invite codes has been introduced for admin users.
	- The user interface for selecting a new admin has been enhanced for better interactivity.

- **Bug Fixes**
	- Corrected a typo in the title string resource for the Space Invite Code screen.

- **Documentation**
	- Added a new string resource indicating code expiration time.

- **Chores**
	- Improved overall structure and layout of the Space Profile screen and Change Admin screen for better user experience.
	- Removed outdated functionality related to invite code regeneration from the Space Invite Code screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->