### PR TITLE
Update the logic for user space leave or remove by admin.

### DIFF
--- a/data/src/main/java/com/canopas/yourspace/data/repository/SpaceRepository.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/SpaceRepository.kt
@@ -215,12 +215,14 @@ class SpaceRepository @Inject constructor(
     suspend fun leaveSpace(spaceId: String) {
         val userId = authService.currentUser?.id ?: ""
         spaceService.removeUserFromSpace(spaceId, userId)
-        val spaces = getUserSpaces(userId)
-        currentSpaceId = spaces.firstOrNull()?.sortedBy { it.created_at }?.firstOrNull()?.id
-            ?: ""
-        val idList = spaces.firstOrNull()?.map { it.id } ?: emptyList()
-        val newUser = authService.currentUser?.copy(space_ids = idList)
-        newUser?.let { authService.updateUser(it) }
+        val user = userService.getUser(userId)
+        val updatedSpaceIds = user?.space_ids?.toMutableList()?.apply {
+            remove(spaceId)
+        } ?: return
+
+        user.copy(space_ids = updatedSpaceIds).let {
+            userService.updateUser(it)
+        }
     }
 
     suspend fun updateSpace(newSpace: ApiSpace) {


### PR DESCRIPTION
# Changelog
- Fix the space_ids removal from user collection.

## Breaking Changes
- Fixes Space ID removal logc from the user.space_ids array when a user leaves or is removed from a space.

## Bug Fixes
- Isntead of updating the whole user collection just update the space_ids array on user's group leave.

## Enhancements
- Optimized user document update process to only add/remove Space ID without affecting other data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced efficiency in leaving a space by streamlining the process of updating user space IDs.
  
- **Bug Fixes**
	- Improved error handling with added logging for exceptions during the admin change process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->