### PR TITLE
Refactor click handling in PermissionContent at EnablePermissionScreen.

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/permission/EnablePermissionsScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/permission/EnablePermissionsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -294,7 +295,14 @@ private fun PermissionContent(
     isGranted: Boolean = false,
     onClick: () -> Unit = {}
 ) {
-    Row(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+    Row(
+        modifier = Modifier
+            .clickable {
+                ripple()
+                onClick()
+            }
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
         Box(
             modifier = Modifier
                 .clip(CircleShape)
@@ -323,14 +331,12 @@ private fun PermissionContent(
         ) {
             Text(
                 text = title,
-                style = AppTheme.appTypography.subTitle2.copy(color = AppTheme.colorScheme.textPrimary),
-                modifier = Modifier.clickable(enabled = !isGranted) { onClick() }
+                style = AppTheme.appTypography.subTitle2.copy(color = AppTheme.colorScheme.textPrimary)
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = description,
-                style = AppTheme.appTypography.body2.copy(color = AppTheme.colorScheme.textDisabled),
-                modifier = Modifier.clickable(enabled = !isGranted) { onClick() }
+                style = AppTheme.appTypography.body2.copy(color = AppTheme.colorScheme.textDisabled)
             )
         }
     }


### PR DESCRIPTION
# Changelog

- Refactored the click handling in the PermissionContent composable to improve maintainability and simplify the UI structure.

## Enhancements
- Consolidated the click handling logic into the parent Row composable.
- Added a ripple effect to the entire row for improved user interaction feedback.


https://github.com/user-attachments/assets/607231ba-fac0-48a8-aef2-078bfc81c0a7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved user interaction with a ripple effect on clickable elements in the permissions screen.
  - Streamlined click handling by consolidating actions to the `Row` component.

- **Bug Fixes**
  - Removed unnecessary clickability from text elements, enhancing clarity in the permissions request UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->