### PR TITLE
Fix the navigation for group deletion or on leave.

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/settings/space/SpaceProfileViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/settings/space/SpaceProfileViewModel.kt
@@ -128,7 +128,7 @@ class SpaceProfileViewModel @Inject constructor(
         val diffInMillis = expireTimeMillis - currentTimeMillis
 
         if (diffInMillis <= 0) {
-            Timber.e("XXX :- The invite code is expired.")
+            Timber.e("The invite code is expired.")
             return "Expired"
         }
 
@@ -195,7 +195,7 @@ class SpaceProfileViewModel @Inject constructor(
                 )
             )
             spaceRepository.deleteSpace(spaceID)
-            navigator.navigateBack(AppDestinations.home.path)
+            navigator.navigateBack()
         } catch (e: Exception) {
             Timber.e(e, "Failed to delete space")
             _state.emit(
@@ -217,7 +217,7 @@ class SpaceProfileViewModel @Inject constructor(
                 )
             )
             spaceRepository.leaveSpace(spaceID)
-            navigator.navigateBack(AppDestinations.home.path)
+            navigator.navigateBack()
         } catch (e: Exception) {
             Timber.e(e, "Failed to leave space")
             _state.emit(

--- a/app/src/test/java/com/canopas/yourspace/ui/flow/settings/space/SpaceProfileViewModelTest.kt
+++ b/app/src/test/java/com/canopas/yourspace/ui/flow/settings/space/SpaceProfileViewModelTest.kt
@@ -326,7 +326,7 @@ class SpaceProfileViewModelTest {
         whenever(authService.currentUser).thenReturn(user1)
         setup()
         viewModel.deleteSpace()
-        verify(navigator).navigateBack(AppDestinations.home.path)
+        verify(navigator).navigateBack()
     }
 
     @Test
@@ -369,7 +369,7 @@ class SpaceProfileViewModelTest {
         whenever(authService.currentUser).thenReturn(user1)
         setup()
         viewModel.leaveSpace()
-        verify(navigator).navigateBack(AppDestinations.home.path)
+        verify(navigator).navigateBack()
     }
 
     @Test


### PR DESCRIPTION
# Changelog
- Fix the navigation for user's group leave or deletion.

## Breaking Changes
- Instead of navigating on the homeScreen navigating user to settingsScren

## Bug Fixes
- When user left or delete the group then it was navigating user to the homeScreen.

https://github.com/user-attachments/assets/95d3b426-ed79-44af-9d7a-cbdf24badf25



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified log message for expired invite code
	- Updated navigation behavior when deleting or leaving a space

<!-- end of auto-generated comment: release notes by coderabbit.ai -->