### PR TITLE
Fix the spaceSelectionMenu appearance for map screen

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/home/HomeScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/home/HomeScreen.kt
@@ -81,7 +81,7 @@ fun HomeScreen(verifyingSpace: Boolean) {
                     modifier = Modifier
                         .padding(it)
                 ) {
-                    HomeScreenContent(navController)
+                    HomeScreenContent(navController, viewModel)
 
                     HomeTopBar(verifyingSpace)
                 }
@@ -207,13 +207,13 @@ private fun MapControl(
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
-fun HomeScreenContent(navController: NavHostController) {
+fun HomeScreenContent(navController: NavHostController, viewModel: HomeScreenViewModel) {
     NavHost(
         navController = navController,
         startDestination = AppDestinations.map.path
     ) {
         tabComposable(AppDestinations.map.path) {
-            MapScreen()
+            MapScreen(viewModel)
         }
 
         tabComposable(AppDestinations.places.path) {

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/home/HomeScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/home/HomeScreen.kt
@@ -81,7 +81,7 @@ fun HomeScreen(verifyingSpace: Boolean) {
                     modifier = Modifier
                         .padding(it)
                 ) {
-                    HomeScreenContent(navController, viewModel)
+                    HomeScreenContent(navController, viewModel::dismissSpaceSelection)
 
                     HomeTopBar(verifyingSpace)
                 }
@@ -207,13 +207,13 @@ private fun MapControl(
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
-fun HomeScreenContent(navController: NavHostController, viewModel: HomeScreenViewModel) {
+fun HomeScreenContent(navController: NavHostController, dismissSpaceSelection: () -> Unit) {
     NavHost(
         navController = navController,
         startDestination = AppDestinations.map.path
     ) {
         tabComposable(AppDestinations.map.path) {
-            MapScreen(viewModel)
+            MapScreen(dismissSpaceSelection)
         }
 
         tabComposable(AppDestinations.places.path) {

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/home/HomeScreenViewModel.kt
@@ -119,6 +119,10 @@ class HomeScreenViewModel @Inject constructor(
             _state.value.copy(showSpaceSelectionPopup = !state.value.showSpaceSelectionPopup)
     }
 
+    fun dismissSpaceSelection() {
+        _state.value = _state.value.copy(showSpaceSelectionPopup = false)
+    }
+
     fun navigateToCreateSpace() {
         navigator.navigateTo(AppDestinations.createSpace.path)
     }

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/map/MapScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/map/MapScreen.kt
@@ -57,7 +57,6 @@ import com.canopas.yourspace.domain.utils.isLocationServiceEnabled
 import com.canopas.yourspace.domain.utils.openLocationSettings
 import com.canopas.yourspace.ui.component.AppBanner
 import com.canopas.yourspace.ui.component.ShowEnableLocationDialog
-import com.canopas.yourspace.ui.flow.home.home.HomeScreenViewModel
 import com.canopas.yourspace.ui.flow.home.map.component.AddMemberBtn
 import com.canopas.yourspace.ui.flow.home.map.component.MapCircles
 import com.canopas.yourspace.ui.flow.home.map.component.MapControlBtn
@@ -86,12 +85,9 @@ private const val DEFAULT_CAMERA_ZOOM_FOR_SELECTED_USER = 17f
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun MapScreen(homeScreenViewModel: HomeScreenViewModel) {
+fun MapScreen(dismissSpaceSelection: () -> Unit) {
     val viewModel = hiltViewModel<MapViewModel>()
     val state by viewModel.state.collectAsState()
-
-    val homeScreenState by homeScreenViewModel.state.collectAsState()
-
     val scope = rememberCoroutineScope()
 
     if (state.errorMessage != null) {
@@ -140,7 +136,7 @@ fun MapScreen(homeScreenViewModel: HomeScreenViewModel) {
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        MapView(cameraPositionState, homeScreenViewModel)
+        MapView(cameraPositionState, dismissSpaceSelection)
 
         Column(
             modifier = Modifier
@@ -149,9 +145,7 @@ fun MapScreen(homeScreenViewModel: HomeScreenViewModel) {
         ) {
             Column(modifier = Modifier.align(Alignment.End)) {
                 MapControlBtn(icon = R.drawable.ic_map_type) {
-                    if (homeScreenState.showSpaceSelectionPopup) {
-                        homeScreenViewModel.dismissSpaceSelection()
-                    }
+                    dismissSpaceSelection()
                     viewModel.toggleStyleSheetVisibility(true)
                 }
 
@@ -160,9 +154,7 @@ fun MapScreen(homeScreenViewModel: HomeScreenViewModel) {
                     show = relocate
                 ) {
                     scope.launch {
-                        if (homeScreenState.showSpaceSelectionPopup) {
-                            homeScreenViewModel.dismissSpaceSelection()
-                        }
+                        dismissSpaceSelection()
                         if (state.isMapLoaded) {
                             cameraPositionState.animate(
                                 CameraUpdateFactory.newLatLngZoom(
@@ -179,9 +171,7 @@ fun MapScreen(homeScreenViewModel: HomeScreenViewModel) {
                         containerColor = AppTheme.colorScheme.primary,
                         contentColor = AppTheme.colorScheme.textInversePrimary
                     ) {
-                        if (homeScreenState.showSpaceSelectionPopup) {
-                            homeScreenViewModel.dismissSpaceSelection()
-                        }
+                        dismissSpaceSelection()
                         viewModel.navigateToPlaces()
                     }
                 }
@@ -225,9 +215,7 @@ fun MapScreen(homeScreenViewModel: HomeScreenViewModel) {
                             }
                             items(state.members) {
                                 MapUserItem(it) {
-                                    if (homeScreenState.showSpaceSelectionPopup) {
-                                        homeScreenViewModel.dismissSpaceSelection()
-                                    }
+                                    dismissSpaceSelection()
                                     viewModel.showMemberDetail(it)
                                 }
                             }
@@ -347,7 +335,7 @@ fun PermissionFooter(onClick: () -> Unit) {
 @Composable
 private fun MapView(
     cameraPositionState: CameraPositionState,
-    homeScreenViewModel: HomeScreenViewModel
+    dismissSpaceSelection: () -> Unit
 ) {
     val viewModel = hiltViewModel<MapViewModel>()
     val state by viewModel.state.collectAsState()
@@ -387,9 +375,7 @@ private fun MapView(
             viewModel.onMapLoaded()
         },
         onMapClick = {
-            if (homeScreenViewModel.state.value.showSpaceSelectionPopup) {
-                homeScreenViewModel.dismissSpaceSelection()
-            }
+            dismissSpaceSelection()
             if (state.showUserDetails) {
                 viewModel.dismissMemberDetail()
             }
@@ -405,9 +391,7 @@ private fun MapView(
                     location = it.location!!,
                     isSelected = it.user.id == state.selectedUser?.user?.id
                 ) {
-                    if (homeScreenViewModel.state.value.showSpaceSelectionPopup) {
-                        homeScreenViewModel.dismissSpaceSelection()
-                    }
+                    dismissSpaceSelection()
                     if (state.isStyleSheetVisible) {
                         viewModel.toggleStyleSheetVisibility(false)
                     }
@@ -423,9 +407,7 @@ private fun MapView(
                     location = location.toApiLocation(currentUser.id),
                     isSelected = currentUser.id == state.selectedUser?.user?.id
                 ) {
-                    if (homeScreenViewModel.state.value.showSpaceSelectionPopup) {
-                        homeScreenViewModel.dismissSpaceSelection()
-                    }
+                    dismissSpaceSelection()
                     if (state.isStyleSheetVisible) {
                         viewModel.toggleStyleSheetVisibility(false)
                     }

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/map/MapViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/map/MapViewModel.kt
@@ -182,7 +182,7 @@ class MapViewModel @Inject constructor(
     }
 
     fun toggleStyleSheetVisibility(isVisible: Boolean) {
-        _state.value = _state.value.copy(isStyleSheetVisible = isVisible)
+        _state.value = _state.value.copy(isStyleSheetVisible = isVisible, showUserDetails = false)
     }
 
     fun showJourneyTimeline() {


### PR DESCRIPTION
# Changelog

- Fixed the appearance of spaceSelectionMenu

## New Features

- On click of outside the spaceSelectionMenu it will close the spaeSelectionMenu.

## Bug Fixes
- It was not closing the space selection menu on outside click of that.

https://github.com/user-attachments/assets/4de5e27c-441d-4fad-80aa-1dd0f82a5446


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced map screen interaction by integrating home screen view model
	- Added ability to dismiss space selection popup

- **Bug Fixes**
	- Improved state management for map and home screen components
	- Added logic to hide user details when toggling style sheet visibility

- **Refactor**
	- Updated method signatures in HomeScreen, MapScreen, and related view models to support better state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->