### PR TITLE
Update seen by id field in message threads

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/messages/chat/MessagesScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/messages/chat/MessagesScreen.kt
@@ -143,6 +143,7 @@ fun MessagesContent(modifier: Modifier) {
                 state.newMessagesToAppend,
                 state.threadMembers,
                 state.currentUserId,
+                state.thread,
                 loadMore = { viewModel.loadMore() }
             )
 

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/messages/chat/MessagesViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/messages/chat/MessagesViewModel.kt
@@ -16,6 +16,7 @@ import com.canopas.yourspace.ui.navigation.AppDestinations.ThreadMessages.KEY_TH
 import com.canopas.yourspace.ui.navigation.AppNavigator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
@@ -94,6 +95,7 @@ class MessagesViewModel @Inject constructor(
 
     private fun markMessagesAsSeen() =
         viewModelScope.launch(appDispatcher.IO) {
+            delay(2000)
             try {
                 val thread = state.value.thread ?: return@launch
                 val userId = state.value.currentUserId
@@ -175,7 +177,7 @@ class MessagesViewModel @Inject constructor(
                             selectedMember = members.filter { it.user.id != state.value.currentUserId }
                         )
                     )
-                    markMessagesAsSeen()
+
                     if (messagesJob == null) listenMessages()
                 }
         }

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/messages/chat/MessagesViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/messages/chat/MessagesViewModel.kt
@@ -86,26 +86,22 @@ class MessagesViewModel @Inject constructor(
                                 newMessagesToAppend = appendedMessages,
                                 messagesByDate = newMessages.groupMessagesByDate()
                             )
-                        markMessagesAsSeen(filter)
+                        markMessagesAsSeen()
                     }
                 }
         }
     }
 
-    private fun markMessagesAsSeen(messages: List<ApiThreadMessage>) =
+    private fun markMessagesAsSeen() =
         viewModelScope.launch(appDispatcher.IO) {
             try {
-                val unreadMessages = messages.distinct()
-                    .filter { !it.seen_by.contains(state.value.currentUserId) }
-                    .map { it.id }
-
-                if (unreadMessages.isNotEmpty()) {
-                    messagesRepository.markMessagesAsSeen(
-                        threadId,
-                        unreadMessages,
-                        state.value.currentUserId
-                    )
+                val thread = state.value.thread ?: return@launch
+                val userId = state.value.currentUserId
+                if (thread.seen_by_ids.contains(userId)) {
+                    return@launch
                 }
+
+                messagesRepository.markMessagesAsSeen(threadId, userId)
             } catch (e: Exception) {
                 Timber.e(e, "Error marking messages as seen")
             }
@@ -140,7 +136,7 @@ class MessagesViewModel @Inject constructor(
                     error = null
                 )
             )
-            markMessagesAsSeen(newMessages)
+            markMessagesAsSeen()
             loadingData = false
         } catch (e: Exception) {
             Timber.e(e, "Error loading messages")
@@ -312,7 +308,10 @@ class MessagesViewModel @Inject constructor(
             val newMessage = messagesRepository.generateMessage(message, userId, threadId)
             val newMessages = state.value.newMessagesToAppend.toMutableList()
             newMessages.add(newMessage)
-            _state.emit(_state.value.copy(newMessagesToAppend = newMessages))
+
+            val thread = state.value.thread?.copy(seen_by_ids = emptyList())
+            _state.emit(_state.value.copy(newMessagesToAppend = newMessages, thread = thread))
+
             messagesRepository.sendMessage(newMessage)
         } catch (e: Exception) {
             Timber.e(e, "Failed to send message")

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/messages/chat/MessagesViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/messages/chat/MessagesViewModel.kt
@@ -136,7 +136,6 @@ class MessagesViewModel @Inject constructor(
                     error = null
                 )
             )
-            markMessagesAsSeen()
             loadingData = false
         } catch (e: Exception) {
             Timber.e(e, "Error loading messages")
@@ -176,7 +175,7 @@ class MessagesViewModel @Inject constructor(
                             selectedMember = members.filter { it.user.id != state.value.currentUserId }
                         )
                     )
-
+                    markMessagesAsSeen()
                     if (messagesJob == null) listenMessages()
                 }
         }

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/messages/chat/components/MessagesList.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/messages/chat/components/MessagesList.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.canopas.yourspace.R
+import com.canopas.yourspace.data.models.messages.ApiThread
 import com.canopas.yourspace.data.models.messages.ApiThreadMessage
 import com.canopas.yourspace.data.models.user.UserInfo
 import com.canopas.yourspace.domain.utils.formattedMessageDateHeader
@@ -55,6 +56,7 @@ fun ColumnScope.MessageList(
     newMessagesToAppend: List<ApiThreadMessage>,
     members: List<UserInfo>,
     currentUserId: String,
+    thread: ApiThread?,
     loadMore: () -> Unit
 ) {
     val reachedBottom by remember {
@@ -98,11 +100,15 @@ fun ColumnScope.MessageList(
             itemsIndexed(messages, key = { _, item -> item.id }) { index, message ->
                 val by = members.firstOrNull { it.user.id == message.sender_id }
 
-                val seenBy =
-                    members.filter { message.seen_by.contains(it.user.id) && it.user.id != currentUserId }
+                val seenBy = if (thread != null) {
+                    members.filter { thread.seen_by_ids.contains(it.user.id) && it.user.id != currentUserId }
+                } else {
+                    emptyList()
+                }
 
                 val myLatestMsg =
                     messages.firstOrNull { it.sender_id == currentUserId }?.id == message.id
+
                 MessageContent(
                     previousMessage = if (index < messages.size - 1) messages[index + 1] else null,
                     nextMessage = if (index > 0 && index < messages.size - 1) messages[index - 1] else null,
@@ -231,6 +237,11 @@ fun MessageBubble(
     } else {
         AppTheme.colorScheme.containerLow
     }
+    val messageTextColor = if (isSender) {
+        AppTheme.colorScheme.textInversePrimary
+    } else {
+        AppTheme.colorScheme.textPrimary
+    }
 
     val shape = if (isSender) {
         RoundedCornerShape(
@@ -278,7 +289,7 @@ fun MessageBubble(
             }
             Text(
                 text = message,
-                style = AppTheme.appTypography.subTitle3.copy(color = AppTheme.colorScheme.textInversePrimary)
+                style = AppTheme.appTypography.subTitle3.copy(color = messageTextColor)
             )
         }
 

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/messages/thread/ThreadsScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/messages/thread/ThreadsScreen.kt
@@ -383,7 +383,7 @@ private fun LazyItemScope.ThreadItem(
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            val hasUnreadMsg = message?.seen_by?.contains(currentUser?.id) == false
+            val hasUnreadMsg = !threadInfo.thread.seen_by_ids.contains(currentUser?.id)
             Text(
                 text = message?.createdAtMs?.formattedMessageTimeString(
                     LocalContext.current

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/messages/thread/ThreadsViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/messages/thread/ThreadsViewModel.kt
@@ -72,7 +72,6 @@ class ThreadsViewModel @Inject constructor(
             val sortedList =
                 threads.filterArchivedThreadsForUser(authService.currentUser!!.id)
                     .sortedByDescending { it.messages.firstOrNull()?.createdAtMs ?: 0 }
-            Timber.d("XXX listenThreads: $sortedList")
             _state.emit(_state.value.copy(threadInfo = sortedList, loadingThreads = false))
         }
     }

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/messages/thread/ThreadsViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/messages/thread/ThreadsViewModel.kt
@@ -72,6 +72,7 @@ class ThreadsViewModel @Inject constructor(
             val sortedList =
                 threads.filterArchivedThreadsForUser(authService.currentUser!!.id)
                     .sortedByDescending { it.messages.firstOrNull()?.createdAtMs ?: 0 }
+            Timber.d("XXX listenThreads: $sortedList")
             _state.emit(_state.value.copy(threadInfo = sortedList, loadingThreads = false))
         }
     }

--- a/data/src/main/java/com/canopas/yourspace/data/models/messages/ApiThread.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/models/messages/ApiThread.kt
@@ -13,12 +13,12 @@ data class ApiThread(
     val id: String = UUID.randomUUID().toString(),
     val admin_id: String = "",
     val space_id: String = "",
-    val last_message:String = "",
+    val last_message: String = "",
     val member_ids: List<String> = emptyList(),
     val seen_by_ids: List<String> = emptyList(),
     val archived_for: Map<String, Long> = emptyMap<String, Long>(),
     val created_at: Long = System.currentTimeMillis(),
-    val last_message_at: Date? = null,
+    val last_message_at: Date? = null
 ) {
     @get:Exclude
     val isGroup: Boolean

--- a/data/src/main/java/com/canopas/yourspace/data/models/messages/ApiThread.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/models/messages/ApiThread.kt
@@ -14,6 +14,7 @@ data class ApiThread(
     val admin_id: String = "",
     val space_id: String = "",
     val member_ids: List<String> = emptyList(),
+    val seen_by_ids: List<String> = emptyList(),
     val archived_for: Map<String, Long> = emptyMap<String, Long>(),
     val created_at: Long = System.currentTimeMillis()
 ) {
@@ -28,7 +29,6 @@ data class ApiThreadMessage(
     val thread_id: String = "",
     val sender_id: String = "",
     val message: String = "",
-    val seen_by: List<String> = emptyList(),
     @ServerTimestamp
     val created_at: Date? = null
 ) {

--- a/data/src/main/java/com/canopas/yourspace/data/models/messages/ApiThread.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/models/messages/ApiThread.kt
@@ -13,10 +13,12 @@ data class ApiThread(
     val id: String = UUID.randomUUID().toString(),
     val admin_id: String = "",
     val space_id: String = "",
+    val last_message:String = "",
     val member_ids: List<String> = emptyList(),
     val seen_by_ids: List<String> = emptyList(),
     val archived_for: Map<String, Long> = emptyMap<String, Long>(),
-    val created_at: Long = System.currentTimeMillis()
+    val created_at: Long = System.currentTimeMillis(),
+    val last_message_at: Date? = null,
 ) {
     @get:Exclude
     val isGroup: Boolean
@@ -29,6 +31,7 @@ data class ApiThreadMessage(
     val thread_id: String = "",
     val sender_id: String = "",
     val message: String = "",
+    val seen_by: List<String> = emptyList(),
     @ServerTimestamp
     val created_at: Date? = null
 ) {

--- a/data/src/main/java/com/canopas/yourspace/data/repository/MessagesRepository.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/MessagesRepository.kt
@@ -58,11 +58,7 @@ class MessagesRepository @Inject constructor(
     fun getLatestMessages(threadId: String, limit: Int) =
         apiMessagesService.getLatestMessages(threadId, limit)
 
-    suspend fun markMessagesAsSeen(
-        threadId: String,
-        messageIds: List<String>,
-        currentUserId: String
-    ) {
-        apiMessagesService.markMessagesAsSeen(threadId, messageIds, currentUserId)
+    suspend fun markMessagesAsSeen(threadId: String, currentUserId: String) {
+        apiMessagesService.markMessagesAsSeen(threadId, currentUserId)
     }
 }

--- a/data/src/main/java/com/canopas/yourspace/data/service/messages/ApiMessagesService.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/messages/ApiMessagesService.kt
@@ -92,8 +92,7 @@ class ApiMessagesService @Inject constructor(
             id = docRef.id,
             thread_id = threadId,
             sender_id = senderId,
-            message = message,
-            seen_by = listOf(senderId)
+            message = message
         )
         docRef.set(threadMessage).await()
     }
@@ -105,8 +104,7 @@ class ApiMessagesService @Inject constructor(
             id = docRef.id,
             thread_id = threadId,
             sender_id = senderId,
-            message = message,
-            seen_by = listOf(senderId)
+            message = message
         )
     }
 
@@ -115,16 +113,8 @@ class ApiMessagesService @Inject constructor(
         docRef.set(message).await()
     }
 
-    suspend fun markMessagesAsSeen(threadId: String, messageIds: List<String>, userId: String) {
-        db.runBatch { batch ->
-            messageIds.forEach { id ->
-                batch.update(
-                    threadMessagesRef(threadId).document(id),
-                    "seen_by",
-                    FieldValue.arrayUnion(userId)
-                )
-            }
-        }.await()
+    suspend fun markMessagesAsSeen(threadId: String, userId: String) {
+        threadRef.document(threadId).update("seen_by_ids", FieldValue.arrayUnion(userId)).await()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
# Changelog

- Update seen by id field in message threads.
- Removed seen_by field from chat message.

Sender device:

[message test.webm](https://github.com/user-attachments/assets/6ec1b512-c0ed-423d-b43e-7619d821865d)


Receiver device:

https://github.com/user-attachments/assets/998077cd-d652-4ef8-a699-d8f4938f9d3f





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced message tracking with thread-level seen status
  - Added last message preview and timestamp to threads

- **Improvements**
  - Simplified message seen status management
  - Improved message bubble color and visibility logic
  - Optimized message marking and tracking mechanisms

- **Bug Fixes**
  - Resolved inconsistencies in message read/unread status tracking

The update focuses on refining the messaging experience with more efficient status tracking and improved visual indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->