### PR TITLE
Rename space to group and GroupTrack to Grouptrack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you are reporting a bug, please help speed up problem diagnosis by providing 
 We actively welcome your pull requests. You can find instructions on building the project in [README.md](https://github.com/canopas/group-track-android).
 1. Fork the repo and create your branch from `master`.  
 2. If you've added code that should be tested, add tests  
-4. Make sure your code lints.  
+3. Make sure your code lints.  
 
 ## Labels
 Labels on issues are managed by contributors, you don't have to worry about them. Here's a list of what they mean:
@@ -29,4 +29,4 @@ Labels on issues are managed by contributors, you don't have to worry about them
  * **non-library**: issue is not in the core library code, but rather in documentation, samples, build process, releases
 
  ## License
- By contributing to GroupTrack, you agree that your contributions will be licensed under its Apache License, Version 2.0. See LICENSE file for details.
+ By contributing to Grouptrack, you agree that your contributions will be licensed under its Apache License, Version 2.0. See LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 <p align="center"> <a href="https://canopas.com/contact"><img src="./screenshots/cta_banner2.png" alt=""></a></p>
 
-# GroupTrack - Stay connected, Anywhere!
+# Grouptrack - Stay connected, Anywhere!
 Enhancing family safety and communication with real-time location sharing and modern UIs.
 
 <img src="./screenshots/cover_image.png"  alt="cover"  width="100%"/>
 
 ## Overview
-Welcome to GroupTrack, an open-source Android application designed to enhance family safety through real-time location sharing and communication features. GroupTrack aims to provide peace of mind by ensuring the safety of your loved ones and facilitating seamless communication regardless of their location.
+Welcome to Grouptrack, an open-source Android application designed to enhance family safety through real-time location sharing and communication features. Grouptrack aims to provide peace of mind by ensuring the safety of your loved ones and facilitating seamless communication regardless of their location.
 
-GroupTrack adopts the MVVM architecture pattern and leverages Jetpack Compose for building modern UIs declaratively. This architecture ensures a clear separation of concerns, making the codebase more maintainable and testable. Jetpack Compose simplifies UI development by allowing developers to define UI elements and their behavior in a more intuitive way, resulting in a seamless user experience.
+Grouptrack adopts the MVVM architecture pattern and leverages Jetpack Compose for building modern UIs declaratively. This architecture ensures a clear separation of concerns, making the codebase more maintainable and testable. Jetpack Compose simplifies UI development by allowing developers to define UI elements and their behavior in a more intuitive way, resulting in a seamless user experience.
 
 ## Download App
 <a href="https://play.google.com/store/apps/details?id=com.canopas.yourspace"><img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" width="200"></img></a>
 
 
 ## Features
-GroupTrack is currently in active development 🚧, with plans to incorporate additional features shortly.
+Grouptrack is currently in active development 🚧, with plans to incorporate additional features shortly.
 
-GroupTrack ensures your loved ones' well-being with:
+Grouptrack ensures your loved ones' well-being with:
 
 - [X] Real-time Location Sharing
 - [X] Secure Communication
@@ -29,7 +29,7 @@ GroupTrack ensures your loved ones' well-being with:
 
 <table>
   <tr>
-    <th width="33%" >Create/Join Space</th>
+    <th width="33%" >Create/Join Group</th>
     <th  width="33%" >Share Location</th>
     <th  width="33%" >Location History</th>
   </tr>
@@ -70,14 +70,14 @@ Use the `applicationId` value specified in the `app/build.gradle` file of the ap
 Once the project is created, you will need to add the `google-services.json` file to the app module.
 For more information, refer to the [Firebase documentation](https://firebase.google.com/docs/android/setup).
 
-GroupTrack uses the following Firebase services, Make sure you enable them in your Firebase project:
+Grouptrack uses the following Firebase services, Make sure you enable them in your Firebase project:
 - Authentication (Phone, Google)
 - Firestore (To store user data)
 </details>
 
 ## Tech stack
 
-GroupTrack utilizes the latest Android technologies and adheres to industry best practices. Below is the current tech stack used in the development process:
+Grouptrack utilizes the latest Android technologies and adheres to industry best practices. Below is the current tech stack used in the development process:
 
 - MVVM Architecture
 - Jetpack Compose
@@ -100,13 +100,13 @@ GroupTrack utilizes the latest Android technologies and adheres to industry best
 The Canopas team enthusiastically welcomes contributions and project participation! There are a bunch of things you can do if you want to contribute! The [Contributor Guide](CONTRIBUTING.md) has all the information you need for everything from reporting bugs to contributing entire new features. Please don't hesitate to jump in if you'd like to, or even ask us questions if something isn't clear.
 
 ## Credits
-GroupTrack is owned and maintained by the [Canopas team](https://canopas.com/). You can follow them on X at [@canopassoftware](https://x.com/canopassoftware) for project updates and releases. If you are interested in building apps or designing products, please let us know. We'd love to hear from you!
+Grouptrack is owned and maintained by the [Canopas team](https://canopas.com/). You can follow them on X at [@canopassoftware](https://x.com/canopassoftware) for project updates and releases. If you are interested in building apps or designing products, please let us know. We'd love to hear from you!
 
 <a href="https://canopas.com/contact"><img src="./screenshots/cta_btn.png" width=300></a>
 
 ## License
 
-GroupTrack is licensed under the Apache License, Version 2.0.
+Grouptrack is licensed under the Apache License, Version 2.0.
 
 ```
 Copyright 2024 Canopas Software LLP

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,11 +28,11 @@
     <string name="common_session_expired_title">You\'ve been logged out</string>
     <string name="common_session_expired_message">You need to sign in again to continue using the application.</string>
     <string name="common_enable_location_service_title">Turn on location/GPS</string>
-    <string name="common_enable_location_service_message">Your location/GPS setting must be turned on for GroupTrack to work. Please turn on location/GPS in the settings</string>
+    <string name="common_enable_location_service_message">Your location/GPS setting must be turned on for Grouptrack to work. Please turn on location/GPS in the settings</string>
     <string name="common_background_access_permission_title">Location Access Required</string>
-    <string name="common_background_access_permission_message">GroupTrack\'s location-sharing feature works correctly when it can access your location all the time. This ensures it gives you accurate, real-time updates.</string>
+    <string name="common_background_access_permission_message">Grouptrack\'s location-sharing feature works correctly when it can access your location all the time. This ensures it gives you accurate, real-time updates.</string>
     <string name="common_background_access_permission_steps">Go to settings > select <b>"Allow all the time"</b></string>
-    <string name="common_background_access_permission_rational_steps">Go to settings > GroupTrack app info > Location permission > select <b>"Allow all the time"</b></string>
+    <string name="common_background_access_permission_rational_steps">Go to settings > Grouptrack app info > Location permission > select <b>"Allow all the time"</b></string>
     <string name="common_background_access_permission_btn">Go to Settings</string>
     <string name="common_space_not_found">No Group Found!</string>
     <string name="common_space_not_found_message">The group you are looking for isn\'t available or you may have been removed.</string>
@@ -94,7 +94,7 @@
     <string name="onboard_space_invalid_invite_code">It appears the code is no longer valid or has expired. Please review and enter a valid code.</string>
 
     <string name="enable_permission_title">Enable Permissions</string>
-    <string name="enable_permission_subtitle">For an effective user experience on GroupTrack, it\'s necessary to enable these permissions.</string>
+    <string name="enable_permission_subtitle">For an effective user experience on Grouptrack, it\'s necessary to enable these permissions.</string>
     <string name="enable_permission_footer">We prioritize the security of your information and want to assure you that we do not share your data with any third-party entities.</string>
     <string name="enable_permission_location_access_title">Location access</string>
     <string name="enable_permission_location_access_desc">For seamless sharing of your live location with a trusted contact requires permission for location access.</string>
@@ -104,7 +104,7 @@
     <string name="enable_permission_notification_access_title">Notification access</string>
     <string name="enable_permission_notification_access_desc">Stay connected and receive timely updates by enabling notification permission for check-ins, alerts, and messages from your trusted one.</string>
     <string name="enable_permission_btn_enable">Enable permission</string>
-    <string name="enable_permission_rational_msg">To receive timely updates, check-ins, and alerts from GroupTrack, grant notification access. We respect your privacy and will only use notifications to enhance your experience. Enable now for seamless communication!</string>
+    <string name="enable_permission_rational_msg">To receive timely updates, check-ins, and alerts from Grouptrack, grant notification access. We respect your privacy and will only use notifications to enhance your experience. Enable now for seamless communication!</string>
     <string name="enable_permission_rational_title">Enable Notification Access</string>
 
     <string name="home_tab_label_home">Home</string>
@@ -112,7 +112,7 @@
     <string name="home_tab_label_places">Places</string>
 
     <string name="home_permission_footer_title">Stay closed to your loved one</string>
-    <string name="home_permission_footer_subtitle">Allow GroupTrack to access your location data.</string>
+    <string name="home_permission_footer_subtitle">Allow Grouptrack to access your location data.</string>
     <string name="home_permission_footer_location_off_subtitle">Device location/GPS is off. Please turn it on!</string>
     <string name="home_permission_footer_missing_location_permission_title">Location sharing is currently not possible</string>
     <string name="home_permission_footer_missing_location_permission_subtitle">Some permissions are missing - grant access</string>
@@ -177,7 +177,7 @@
     <string name="setting_app_version">App version: %s</string>
     <string name="setting_share_app">Share app</string>
     <string name="setting_rate_app">Rate us</string>
-    <string name="app_share_message">Check out GroupTrack - the best app to stay connected with your loved ones! Download now: %1$s</string>
+    <string name="app_share_message">Check out Grouptrack - the best app to stay connected with your loved ones! Download now: %1$s</string>
 
     <string name="edit_profile_title">Edit profile</string>
     <string name="edit_profile_toolbar_save_text">Save</string>
@@ -225,7 +225,7 @@
     <string name="setting_spaces">Your groups</string>
 
     <string name="battery_optimization_dialog_title">Turn off Battery Optimization for Location Sharing</string>
-    <string name="battery_optimization_dialog_message">For location sharing feature to work properly for your Groups, turn off Battery Optimization in your phone settings for the GroupTrack app. This won\'t affect your other apps.</string>
+    <string name="battery_optimization_dialog_message">For location sharing feature to work properly for your Groups, turn off Battery Optimization in your phone settings for the Grouptrack app. This won\'t affect your other apps.</string>
     <string name="battery_optimization_dialog_btn_change_now">Change now</string>
 
     <string name="places_list_title">Places</string>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,2 @@
-title: GroupTrack - Stay connected, Anywhere!
+title: Grouptrack - Stay connected, Anywhere!
 description: Enhance family safety with real-time location sharing.

--- a/docs/account-deletion-guide.md
+++ b/docs/account-deletion-guide.md
@@ -1,9 +1,9 @@
-# GroupTrack Account Deletion
+# Grouptrack Account Deletion
 
-If you wish to delete your GroupTrack account, follow these steps:
+If you wish to delete your Grouptrack account, follow these steps:
 (Note : If you're an admin of any group, you must have to transfer admin rights to another user before proceeding.)
 
-1. Open the **GroupTrack** app on your device.
+1. Open the **Grouptrack** app on your device.
 
 2. Go to **Home** and tap on **Settings**.
 

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -19,11 +19,11 @@ For the purposes of this Privacy Policy:
 - __Account__ means a unique account created for You to access our Service or parts of our Service.
 - __Affiliate__ means an entity that controls, is controlled by or is under common control with a party, where "control" means ownership of 50% or more of the shares, equity interest or other securities entitled to vote for election of directors or other managing authority.
 
-- __Application__ refers to GroupTrack, the software program provided by the Company.
+- __Application__ refers to Grouptrack, the software program provided by the Company.
 
 
 
-- __Company__ (referred to as either "the Company", "We", "Us" or "Our" in this Agreement) refers to GroupTrack.
+- __Company__ (referred to as either "the Company", "We", "Us" or "Our" in this Agreement) refers to Grouptrack.
 
 
 


### PR DESCRIPTION
# Changelog
- Rename space to group for Readme file 
- Rename GroupTrack to Grouptrack for `CONTRIBUTING.md`, `README.md`, `Strings.xml` ...etc files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Renamed "GroupTrack" to "Grouptrack" across multiple documentation files
	- Updated application name in README, configuration files, account deletion guide, and privacy policy
	- Minor text and formatting adjustments

- **Chores**
	- Standardized application branding and capitalization in user interface strings and documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->