### PR TITLE
Add fallback for empty userId by using null in Firestore query

### DIFF
--- a/data/src/main/java/com/canopas/yourspace/data/service/user/ApiUserService.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/user/ApiUserService.kt
@@ -49,7 +49,8 @@ class ApiUserService @Inject constructor(
 
     suspend fun getUser(userId: String): ApiUser? {
         return try {
-            val user = userRef.document(userId).get().await().toObject(ApiUser::class.java)
+            val user = userRef.document(userId.takeIf { it.isNotBlank() } ?: "null").get().await()
+                .toObject(ApiUser::class.java)
             when {
                 user == null -> null
                 currentUser == null || user.id != currentUser.id -> user
@@ -107,7 +108,7 @@ class ApiUserService @Inject constructor(
                 last_name = account?.familyName ?: "",
                 provider_firebase_id_token = firebaseToken,
                 profile_image = account?.photoUrl?.toString() ?: firebaseUser?.photoUrl?.toString()
-                    ?: ""
+                ?: ""
             )
             userRef.document(uid).set(user).await()
             val sessionDocRef = sessionRef(user.id).document()

--- a/data/src/main/java/com/canopas/yourspace/data/service/user/ApiUserService.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/user/ApiUserService.kt
@@ -108,7 +108,7 @@ class ApiUserService @Inject constructor(
                 last_name = account?.familyName ?: "",
                 provider_firebase_id_token = firebaseToken,
                 profile_image = account?.photoUrl?.toString() ?: firebaseUser?.photoUrl?.toString()
-                ?: ""
+                    ?: ""
             )
             userRef.document(uid).set(user).await()
             val sessionDocRef = sessionRef(user.id).document()


### PR DESCRIPTION
# Changelog

Added fallback for empty userId in Firestore query

## Enhancements

- Improved Firestore query behavior by ensuring that an empty userId is replaced with "null" instead of causing potential issues in document retrieval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of user ID retrieval to prevent errors with blank user IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->