### PR TITLE
Fix distance calculation for moving journey

### DIFF
--- a/data/src/main/java/com/canopas/yourspace/data/repository/JourneyGenerator.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/repository/JourneyGenerator.kt
@@ -142,7 +142,7 @@ fun getJourney(
             val updatedJourney = lastKnownJourney.copy(
                 to_latitude = newLocation.latitude,
                 to_longitude = newLocation.longitude,
-                route_distance = distance,
+                route_distance = (lastKnownJourney.route_distance ?: 0.0) + distance,
                 route_duration = lastKnownJourney.updated_at -
                     lastKnownJourney.created_at,
                 routes = lastKnownJourney.routes + newLocation.toRoute()


### PR DESCRIPTION
# Changelog
- Fix distance calculation saving for moving journey

## Bug Fixes
- Instead of saving the last two routes distance, save the whole route's distance 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved journey distance tracking accuracy by correctly accumulating total route distance during user movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->